### PR TITLE
Review of #17

### DIFF
--- a/R/install_ducklake.R
+++ b/R/install_ducklake.R
@@ -26,9 +26,11 @@ install_ducklake <- function(backend = NULL) {
   # SELECT version() returns the DuckDB engine version, not the R package version.
   conn <- get_ducklake_connection()
   duckdb_version <- DBI::dbGetQuery(conn, "SELECT version()")[1, 1]
-  duckdb_version_numeric <- as.integer(gsub("\\.", "", sub("^v", "", duckdb_version)))
-  if (duckdb_version_numeric < 151) {
-    cli::cli_abort("DuckLake v1.0 requires DuckDB version 1.5.1 or higher (found {duckdb_version}).")
+  duckdb_version_parsed <- numeric_version(sub("^v", "", duckdb_version))
+  if (duckdb_version_parsed < "1.5.1") {
+    cli::cli_abort(
+      "DuckLake v1.0 requires DuckDB version 1.5.1 or higher (found {duckdb_version})."
+    )
   }
 
   # the long messages thrown on load for duckplyr are suppressed here

--- a/R/transactions.R
+++ b/R/transactions.R
@@ -36,7 +36,7 @@ begin_transaction <- function(conn = NULL) {
   if (is.null(conn)) {
     conn <- get_ducklake_connection()
   }
-  
+
   DBI::dbExecute(conn, "BEGIN TRANSACTION;")
   cli::cli_inform("Transaction started.")
   invisible(TRUE)
@@ -70,7 +70,7 @@ begin_transaction <- function(conn = NULL) {
 #' begin_transaction()
 #' # ... make changes ...
 #' commit_transaction()
-#' 
+#'
 #' # Commit with metadata
 #' begin_transaction()
 #' create_table(mtcars, "cars")
@@ -79,20 +79,26 @@ begin_transaction <- function(conn = NULL) {
 #'   commit_message = "Add cars dataset"
 #' )
 #' }
-commit_transaction <- function(conn = NULL, author = NULL, commit_message = NULL,
-                                commit_extra_info = NULL) {
+commit_transaction <- function(
+  conn = NULL,
+  author = NULL,
+  commit_message = NULL,
+  commit_extra_info = NULL
+) {
   if (is.null(conn)) {
     conn <- get_ducklake_connection()
   }
-  
+
   # In DuckLake v1.0, commit metadata must be set within the transaction
   # using CALL set_commit_message() before COMMIT
-  if (!is.null(author) || !is.null(commit_message) || !is.null(commit_extra_info)) {
+  if (
+    !is.null(author) || !is.null(commit_message) || !is.null(commit_extra_info)
+  ) {
     current_db <- tryCatch(
       DBI::dbGetQuery(conn, "SELECT current_database() as db")$db,
       error = function(e) NULL
     )
-    
+
     if (!is.null(current_db) && current_db != "") {
       # Build the CALL set_commit_message() statement
       # Signature: CALL ducklake.set_commit_message(author, message, extra_info => '...')
@@ -106,20 +112,25 @@ commit_transaction <- function(conn = NULL, author = NULL, commit_message = NULL
       } else {
         "NULL"
       }
-      
+
       if (!is.null(commit_extra_info)) {
         extra_sql <- sprintf("'%s'", gsub("'", "''", commit_extra_info))
         call_sql <- sprintf(
           "CALL %s.set_commit_message(%s, %s, extra_info => %s)",
-          current_db, author_sql, message_sql, extra_sql
+          current_db,
+          author_sql,
+          message_sql,
+          extra_sql
         )
       } else {
         call_sql <- sprintf(
           "CALL %s.set_commit_message(%s, %s)",
-          current_db, author_sql, message_sql
+          current_db,
+          author_sql,
+          message_sql
         )
       }
-      
+
       tryCatch(
         DBI::dbExecute(conn, call_sql),
         error = function(e) {
@@ -130,10 +141,10 @@ commit_transaction <- function(conn = NULL, author = NULL, commit_message = NULL
       cli::cli_warn("Could not determine ducklake name; metadata not set.")
     }
   }
-  
+
   DBI::dbExecute(conn, "COMMIT;")
   cli::cli_inform("Transaction committed.")
-  
+
   invisible(TRUE)
 }
 
@@ -163,7 +174,7 @@ commit_transaction <- function(conn = NULL, author = NULL, commit_message = NULL
 #' begin_transaction()
 #' # ... make changes ...
 #' commit_transaction()
-#' 
+#'
 #' # Add metadata to the snapshot after the fact
 #' set_snapshot_metadata(
 #'   ducklake_name = "my_ducklake",
@@ -171,54 +182,69 @@ commit_transaction <- function(conn = NULL, author = NULL, commit_message = NULL
 #'   commit_message = "Updated station names for clarity"
 #' )
 #' }
-set_snapshot_metadata <- function(ducklake_name, author = NULL, commit_message = NULL,
-                                   commit_extra_info = NULL, conn = NULL) {
+set_snapshot_metadata <- function(
+  ducklake_name,
+  author = NULL,
+  commit_message = NULL,
+  commit_extra_info = NULL,
+  conn = NULL
+) {
   if (is.null(conn)) {
     conn <- get_ducklake_connection()
   }
-  
-  if (is.null(author) && is.null(commit_message) && is.null(commit_extra_info)) {
+
+  if (
+    is.null(author) && is.null(commit_message) && is.null(commit_extra_info)
+  ) {
     cli::cli_warn("No metadata provided to set.")
     return(invisible(FALSE))
   }
-  
-  # Build SET clauses for the UPDATE
-  set_clauses <- c()
+
+  # Build parameterized SET clause to prevent SQL injection
+  set_parts <- character()
+  params <- list()
   if (!is.null(author)) {
-    set_clauses <- c(set_clauses,
-      sprintf("author = '%s'", gsub("'", "''", author)))
+    set_parts <- c(set_parts, "author = ?")
+    params <- c(params, list(author))
   }
   if (!is.null(commit_message)) {
-    set_clauses <- c(set_clauses,
-      sprintf("commit_message = '%s'", gsub("'", "''", commit_message)))
+    set_parts <- c(set_parts, "commit_message = ?")
+    params <- c(params, list(commit_message))
   }
   if (!is.null(commit_extra_info)) {
-    set_clauses <- c(set_clauses,
-      sprintf("commit_extra_info = '%s'", gsub("'", "''", commit_extra_info)))
+    set_parts <- c(set_parts, "commit_extra_info = ?")
+    params <- c(params, list(commit_extra_info))
   }
-  
-  # Qualify the metadata table name based on backend
+
+  # Qualify metadata table names based on backend
   backend <- get_ducklake_backend()
   meta_db <- paste0("__ducklake_metadata_", ducklake_name)
   if (backend %in% c("postgres", "mysql")) {
-    tbl_ref <- sprintf("\"%s\".ducklake_snapshot_changes", meta_db)
+    changes_ref <- sprintf("\"%s\".ducklake_snapshot_changes", meta_db)
+    snapshot_ref <- sprintf("\"%s\".ducklake_snapshot", meta_db)
   } else {
-    tbl_ref <- sprintf("\"%s\".main.ducklake_snapshot_changes", meta_db)
+    changes_ref <- sprintf("\"%s\".main.ducklake_snapshot_changes", meta_db)
+    snapshot_ref <- sprintf("\"%s\".main.ducklake_snapshot", meta_db)
   }
-  
+
   update_sql <- sprintf(
     "UPDATE %s SET %s WHERE snapshot_id = (SELECT MAX(snapshot_id) FROM %s)",
-    tbl_ref, paste(set_clauses, collapse = ", "), tbl_ref
+    changes_ref,
+    paste(set_parts, collapse = ", "),
+    snapshot_ref
   )
-  
-  tryCatch({
-    DBI::dbExecute(conn, update_sql)
-    cli::cli_inform("Snapshot metadata updated.")
-    invisible(TRUE)
-  }, error = function(e) {
-    cli::cli_warn("Could not update snapshot metadata: {e$message}")
-    invisible(FALSE)
-  })
+
+  tryCatch(
+    {
+      DBI::dbExecute(conn, update_sql, params = params)
+      cli::cli_inform("Snapshot metadata updated.")
+      invisible(TRUE)
+    },
+    error = function(e) {
+      cli::cli_warn("Could not update snapshot metadata: {e$message}")
+      invisible(FALSE)
+    }
+  )
 }
 
 #' Execute code within a transaction
@@ -283,27 +309,38 @@ set_snapshot_metadata <- function(ducklake_name, author = NULL, commit_message =
 #'   error = function(e) message("Transaction was rolled back: ", e$message)
 #' )
 #' }
-with_transaction <- function(expr, author = NULL, commit_message = NULL,
-                             commit_extra_info = NULL, conn = NULL) {
+with_transaction <- function(
+  expr,
+  author = NULL,
+  commit_message = NULL,
+  commit_extra_info = NULL,
+  conn = NULL
+) {
   if (is.null(conn)) {
     conn <- get_ducklake_connection()
   }
-  
+
   begin_transaction(conn = conn)
-  
-  tryCatch({
-    result <- force(expr)
-    commit_transaction(
-      conn = conn,
-      author = author,
-      commit_message = commit_message,
-      commit_extra_info = commit_extra_info
-    )
-    invisible(result)
-  }, error = function(e) {
-    rollback_transaction(conn = conn)
-    cli::cli_abort("Transaction rolled back due to error: {e$message}", call = NULL)
-  })
+
+  tryCatch(
+    {
+      result <- force(expr)
+      commit_transaction(
+        conn = conn,
+        author = author,
+        commit_message = commit_message,
+        commit_extra_info = commit_extra_info
+      )
+      invisible(result)
+    },
+    error = function(e) {
+      rollback_transaction(conn = conn)
+      cli::cli_abort(
+        "Transaction rolled back due to error: {e$message}",
+        call = NULL
+      )
+    }
+  )
 }
 
 #' Rollback a transaction
@@ -331,7 +368,7 @@ rollback_transaction <- function(conn = NULL) {
   if (is.null(conn)) {
     conn <- get_ducklake_connection()
   }
-  
+
   DBI::dbExecute(conn, "ROLLBACK;")
   cli::cli_inform("Transaction rolled back.")
   invisible(TRUE)

--- a/tests/testthat/test-data-inlining.R
+++ b/tests/testthat/test-data-inlining.R
@@ -15,11 +15,16 @@ test_that("attach_ducklake accepts data_inlining_row_limit parameter", {
 
   temp_dir <- tempfile()
   dir.create(temp_dir, showWarnings = FALSE, recursive = TRUE)
-  ducklake_name <- paste0("test_inline_attach_", format(Sys.time(), "%Y%m%d%H%M%S"))
+  ducklake_name <- paste0(
+    "test_inline_attach_",
+    format(Sys.time(), "%Y%m%d%H%M%S")
+  )
 
   # Build SQL with inlining limit and verify it appears in the statement
   sql <- build_attach_sql(
-    ducklake_name, temp_dir, "duckdb",
+    ducklake_name,
+    temp_dir,
+    "duckdb",
     catalog_connection_string = NULL,
     read_only = FALSE,
     override_data_path = FALSE,
@@ -30,7 +35,9 @@ test_that("attach_ducklake accepts data_inlining_row_limit parameter", {
   # Build SQL without inlining limit and verify it does NOT appear
 
   sql_no_limit <- build_attach_sql(
-    ducklake_name, temp_dir, "duckdb",
+    ducklake_name,
+    temp_dir,
+    "duckdb",
     catalog_connection_string = NULL,
     read_only = FALSE,
     override_data_path = FALSE
@@ -64,7 +71,10 @@ test_that("small inserts are inlined (no Parquet files created)", {
   conn <- get_ducklake_connection()
   file_count <- DBI::dbGetQuery(
     conn,
-    sprintf("SELECT count(*) AS n FROM ducklake_list_files('%s', 'readings');", lake$ducklake_name)
+    sprintf(
+      "SELECT count(*) AS n FROM ducklake_list_files('%s', 'readings');",
+      lake$ducklake_name
+    )
   )$n
   expect_equal(file_count, 0L)
 
@@ -92,7 +102,10 @@ test_that("large inserts bypass inlining and write Parquet", {
   conn <- get_ducklake_connection()
   file_count <- DBI::dbGetQuery(
     conn,
-    sprintf("SELECT count(*) AS n FROM ducklake_list_files('%s', 'big_table');", lake$ducklake_name)
+    sprintf(
+      "SELECT count(*) AS n FROM ducklake_list_files('%s', 'big_table');",
+      lake$ducklake_name
+    )
   )$n
   expect_gt(file_count, 0L)
 
@@ -151,7 +164,10 @@ test_that("set_inlining_row_limit(0) disables inlining", {
   conn <- get_ducklake_connection()
   file_count <- DBI::dbGetQuery(
     conn,
-    sprintf("SELECT count(*) AS n FROM ducklake_list_files('%s', 'no_inline');", ducklake_name)
+    sprintf(
+      "SELECT count(*) AS n FROM ducklake_list_files('%s', 'no_inline');",
+      ducklake_name
+    )
   )$n
   expect_gt(file_count, 0L)
 
@@ -180,12 +196,18 @@ test_that("flush_inlined_data materialises inlined rows to Parquet", {
   conn <- get_ducklake_connection()
   before <- DBI::dbGetQuery(
     conn,
-    sprintf("SELECT count(*) AS n FROM ducklake_list_files('%s', 'flush_test');", lake$ducklake_name)
+    sprintf(
+      "SELECT count(*) AS n FROM ducklake_list_files('%s', 'flush_test');",
+      lake$ducklake_name
+    )
   )$n
   expect_equal(before, 0L)
 
   # Flush inlined data
-  flush_result <- flush_inlined_data(ducklake_name = lake$ducklake_name)
+  flush_result <- flush_inlined_data(
+    ducklake_name = lake$ducklake_name,
+    table_name = "flush_test"
+  )
   expect_true(is.data.frame(flush_result))
   expect_gt(nrow(flush_result), 0L)
   expect_true("rows_flushed" %in% names(flush_result))
@@ -194,7 +216,10 @@ test_that("flush_inlined_data materialises inlined rows to Parquet", {
   # After flush: Parquet files should exist in DuckLake's file list
   after <- DBI::dbGetQuery(
     conn,
-    sprintf("SELECT count(*) AS n FROM ducklake_list_files('%s', 'flush_test');", lake$ducklake_name)
+    sprintf(
+      "SELECT count(*) AS n FROM ducklake_list_files('%s', 'flush_test');",
+      lake$ducklake_name
+    )
   )$n
   expect_gt(after, 0L)
 
@@ -232,14 +257,20 @@ test_that("flush_inlined_data can target a specific table", {
   # tbl_a should now have Parquet files (flushed)
   files_a <- DBI::dbGetQuery(
     get_ducklake_connection(),
-    sprintf("SELECT count(*) AS n FROM ducklake_list_files('%s', 'tbl_a');", lake$ducklake_name)
+    sprintf(
+      "SELECT count(*) AS n FROM ducklake_list_files('%s', 'tbl_a');",
+      lake$ducklake_name
+    )
   )$n
   expect_gt(files_a, 0L)
 
   # tbl_b should still be inlined (no Parquet files)
   files_b <- DBI::dbGetQuery(
     get_ducklake_connection(),
-    sprintf("SELECT count(*) AS n FROM ducklake_list_files('%s', 'tbl_b');", lake$ducklake_name)
+    sprintf(
+      "SELECT count(*) AS n FROM ducklake_list_files('%s', 'tbl_b');",
+      lake$ducklake_name
+    )
   )$n
   expect_equal(files_b, 0L)
 
@@ -278,7 +309,10 @@ test_that("checkpoint_ducklake runs maintenance", {
   conn <- get_ducklake_connection()
   files_before <- DBI::dbGetQuery(
     conn,
-    sprintf("SELECT count(*) AS n FROM ducklake_list_files('%s', 'checkpoint_test');", lake$ducklake_name)
+    sprintf(
+      "SELECT count(*) AS n FROM ducklake_list_files('%s', 'checkpoint_test');",
+      lake$ducklake_name
+    )
   )$n
 
   # Checkpoint should complete without error
@@ -287,7 +321,10 @@ test_that("checkpoint_ducklake runs maintenance", {
   # After checkpoint: inlined row should be flushed to Parquet
   files_after <- DBI::dbGetQuery(
     conn,
-    sprintf("SELECT count(*) AS n FROM ducklake_list_files('%s', 'checkpoint_test');", lake$ducklake_name)
+    sprintf(
+      "SELECT count(*) AS n FROM ducklake_list_files('%s', 'checkpoint_test');",
+      lake$ducklake_name
+    )
   )$n
   expect_gt(files_after, files_before)
 
@@ -314,7 +351,10 @@ test_that("inlined data supports time travel", {
   )
 
   # Get snapshot info after creation
-  snapshots_before <- list_table_snapshots("time_travel_inline", ducklake_name = lake$ducklake_name)
+  snapshots_before <- list_table_snapshots(
+    "time_travel_inline",
+    ducklake_name = lake$ducklake_name
+  )
 
   # Incrementally add a row (exercises true per-row inlining)
   rows_insert(
@@ -332,7 +372,10 @@ test_that("inlined data supports time travel", {
 
   # Time travel to first snapshot should show 3 rows
   first_version <- snapshots_before$snapshot_id[1]
-  historical <- get_ducklake_table_version("time_travel_inline", first_version) |>
+  historical <- get_ducklake_table_version(
+    "time_travel_inline",
+    first_version
+  ) |>
     dplyr::collect()
   expect_equal(nrow(historical), 3)
 
@@ -385,7 +428,7 @@ test_that("set/get_inlining_row_limit works per-table", {
     commit_message = "create per_tbl_test"
   )
 
- # Set per-table limit (auto-detects ducklake_name)
+  # Set per-table limit (auto-detects ducklake_name)
   set_inlining_row_limit(75, table_name = "per_tbl_test")
 
   # Query per-table limit (auto-detects ducklake_name)
@@ -480,7 +523,10 @@ test_that("flush_inlined_data works with schema_name filter", {
   conn <- get_ducklake_connection()
   before <- DBI::dbGetQuery(
     conn,
-    sprintf("SELECT count(*) AS n FROM ducklake_list_files('%s', 'schema_flush');", lake$ducklake_name)
+    sprintf(
+      "SELECT count(*) AS n FROM ducklake_list_files('%s', 'schema_flush');",
+      lake$ducklake_name
+    )
   )$n
   expect_equal(before, 0L)
 
@@ -496,7 +542,10 @@ test_that("flush_inlined_data works with schema_name filter", {
   # After flush: Parquet files should exist
   after <- DBI::dbGetQuery(
     conn,
-    sprintf("SELECT count(*) AS n FROM ducklake_list_files('%s', 'schema_flush');", lake$ducklake_name)
+    sprintf(
+      "SELECT count(*) AS n FROM ducklake_list_files('%s', 'schema_flush');",
+      lake$ducklake_name
+    )
   )$n
   expect_gt(after, 0L)
 
@@ -522,7 +571,10 @@ test_that("flush_inlined_data works with table_name and schema_name", {
   conn <- get_ducklake_connection()
   before <- DBI::dbGetQuery(
     conn,
-    sprintf("SELECT count(*) AS n FROM ducklake_list_files('%s', 'combo_flush');", lake$ducklake_name)
+    sprintf(
+      "SELECT count(*) AS n FROM ducklake_list_files('%s', 'combo_flush');",
+      lake$ducklake_name
+    )
   )$n
   expect_equal(before, 0L)
 
@@ -539,7 +591,10 @@ test_that("flush_inlined_data works with table_name and schema_name", {
   # After flush: Parquet files should exist
   after <- DBI::dbGetQuery(
     conn,
-    sprintf("SELECT count(*) AS n FROM ducklake_list_files('%s', 'combo_flush');", lake$ducklake_name)
+    sprintf(
+      "SELECT count(*) AS n FROM ducklake_list_files('%s', 'combo_flush');",
+      lake$ducklake_name
+    )
   )$n
   expect_gt(after, 0L)
 
@@ -564,7 +619,10 @@ test_that("checkpoint_ducklake auto-detects ducklake_name", {
   conn <- get_ducklake_connection()
   before <- DBI::dbGetQuery(
     conn,
-    sprintf("SELECT count(*) AS n FROM ducklake_list_files('%s', 'ckpt_auto');", lake$ducklake_name)
+    sprintf(
+      "SELECT count(*) AS n FROM ducklake_list_files('%s', 'ckpt_auto');",
+      lake$ducklake_name
+    )
   )$n
   expect_equal(before, 0L)
 
@@ -574,7 +632,10 @@ test_that("checkpoint_ducklake auto-detects ducklake_name", {
   # After checkpoint: inlined data should be flushed to Parquet
   after <- DBI::dbGetQuery(
     conn,
-    sprintf("SELECT count(*) AS n FROM ducklake_list_files('%s', 'ckpt_auto');", lake$ducklake_name)
+    sprintf(
+      "SELECT count(*) AS n FROM ducklake_list_files('%s', 'ckpt_auto');",
+      lake$ducklake_name
+    )
   )$n
   expect_gt(after, 0L)
 
@@ -599,7 +660,10 @@ test_that("flush_inlined_data auto-detects ducklake_name", {
   conn <- get_ducklake_connection()
   before <- DBI::dbGetQuery(
     conn,
-    sprintf("SELECT count(*) AS n FROM ducklake_list_files('%s', 'flush_auto');", lake$ducklake_name)
+    sprintf(
+      "SELECT count(*) AS n FROM ducklake_list_files('%s', 'flush_auto');",
+      lake$ducklake_name
+    )
   )$n
   expect_equal(before, 0L)
 
@@ -611,7 +675,10 @@ test_that("flush_inlined_data auto-detects ducklake_name", {
   # After flush: Parquet files should exist
   after <- DBI::dbGetQuery(
     conn,
-    sprintf("SELECT count(*) AS n FROM ducklake_list_files('%s', 'flush_auto');", lake$ducklake_name)
+    sprintf(
+      "SELECT count(*) AS n FROM ducklake_list_files('%s', 'flush_auto');",
+      lake$ducklake_name
+    )
   )$n
   expect_gt(after, 0L)
 

--- a/vignettes/clinical-trial-datalake.Rmd
+++ b/vignettes/clinical-trial-datalake.Rmd
@@ -13,8 +13,7 @@ vignette: >
 has_deps <- requireNamespace("pharmaversesdtm", quietly = TRUE) &&
   requireNamespace("admiral", quietly = TRUE)
 duckdb_version_ok <- tryCatch({
-  v <- as.integer(gsub("\\.", "", sub("^v", "", packageVersion("duckdb"))))
-  v >= 151
+  packageVersion("duckdb") >= "1.5.1"
 }, error = function(e) FALSE)
 knitr::opts_chunk$set(
   collapse = TRUE,

--- a/vignettes/data-inlining.Rmd
+++ b/vignettes/data-inlining.Rmd
@@ -10,8 +10,7 @@ vignette: >
 ```{r, include = FALSE}
 # Skip if the duckdb R package is too old to support the ducklake v1.0 extension
 duckdb_version_ok <- tryCatch({
-  v <- as.integer(gsub("\\.", "", sub("^v", "", packageVersion("duckdb"))))
-  v >= 151
+  packageVersion("duckdb") >= "1.5.1"
 }, error = function(e) FALSE)
 knitr::opts_chunk$set(
   collapse = TRUE,

--- a/vignettes/modifying-tables.Rmd
+++ b/vignettes/modifying-tables.Rmd
@@ -10,8 +10,7 @@ vignette: >
 ```{r, include = FALSE}
 # Skip if the duckdb R package is too old to support the ducklake v1.0 extension
 duckdb_version_ok <- tryCatch({
-  v <- as.integer(gsub("\\.", "", sub("^v", "", packageVersion("duckdb"))))
-  v >= 151
+  packageVersion("duckdb") >= "1.5.1"
 }, error = function(e) FALSE)
 knitr::opts_chunk$set(
   collapse = TRUE,

--- a/vignettes/storage-and-backups.Rmd
+++ b/vignettes/storage-and-backups.Rmd
@@ -10,8 +10,7 @@ vignette: >
 ```{r, include = FALSE}
 # Skip if the duckdb R package is too old to support the ducklake v1.0 extension
 duckdb_version_ok <- tryCatch({
-  v <- as.integer(gsub("\\.", "", sub("^v", "", packageVersion("duckdb"))))
-  v >= 151
+  packageVersion("duckdb") >= "1.5.1"
 }, error = function(e) FALSE)
 knitr::opts_chunk$set(
   collapse = TRUE,

--- a/vignettes/time-travel.Rmd
+++ b/vignettes/time-travel.Rmd
@@ -10,8 +10,7 @@ vignette: >
 ```{r, include = FALSE}
 # Skip if the duckdb R package is too old to support the ducklake v1.0 extension
 duckdb_version_ok <- tryCatch({
-  v <- as.integer(gsub("\\.", "", sub("^v", "", packageVersion("duckdb"))))
-  v >= 151
+  packageVersion("duckdb") >= "1.5.1"
 }, error = function(e) FALSE)
 knitr::opts_chunk$set(
   collapse = TRUE,

--- a/vignettes/transactions.Rmd
+++ b/vignettes/transactions.Rmd
@@ -10,8 +10,7 @@ vignette: >
 ```{r, include = FALSE}
 # Skip if the duckdb R package is too old to support the ducklake v1.0 extension
 duckdb_version_ok <- tryCatch({
-  v <- as.integer(gsub("\\.", "", sub("^v", "", packageVersion("duckdb"))))
-  v >= 151
+  packageVersion("duckdb") >= "1.5.1"
 }, error = function(e) FALSE)
 knitr::opts_chunk$set(
   collapse = TRUE,


### PR DESCRIPTION
I went through the v0.3 / ducklake-v1 changes in detail. The overall PR looks great, the `set_commit_message()` migration, the data inlining wrappers, and tests all look solid. Two things I'd fix:

### 1. `set_snapshot_metadata()`: fix MAX subquery table & restore parameterized queries

The refactored `set_snapshot_metadata()` queries `MAX(snapshot_id)` from `ducklake_snapshot_changes` instead of `ducklake_snapshot`. The old code correctly targeted `ducklake_snapshot` (the canonical source of snapshot IDs). Also restored `?`-placeholder parameterized queries (as in v0.2) instead of manual `gsub("'", "''", ...)` escaping, the `CALL` path in `commit_transaction()` needs manual escaping, but the plain `UPDATE` in `set_snapshot_metadata()` doesn't.

### 2. Simplified version comparisons

Replaced the `gsub("\\.", "") → integer` version comparison pattern with `numeric_version()` / `packageVersion()` comparisons. The old pattern breaks if a version component ever exceeds a single digit (e.g., `1.5.10` → `1510` vs threshold `151`). Affects `install_ducklake.R` and the vignette version guards.