### PR TITLE
Render time-travel timestamps in UTC with sub-second precision

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,13 @@
 * Timestamps passed to the new functions as POSIXct are converted to UTC
   before interpolation, matching how DuckLake records snapshot times.
 
+* `get_ducklake_table_asof()` and `restore_table_version()` now also convert
+  POSIXct timestamps to UTC. Previously they rendered local time, which
+  DuckLake reads as UTC, silently shifting the queried instant by the UTC
+  offset -- a bare `Sys.time()` looked hours in the past (or future) unless
+  the session's timezone was UTC. Timestamps taken from
+  `list_table_snapshots()$snapshot_time` are unaffected.
+
 * `attach_ducklake()` now collapses duplicate slashes in `lake_path` (remote
   URIs are untouched). DuckLake compares file paths as exact strings, so a
   doubled slash -- which R's `tempdir()` produces on macOS -- made

--- a/R/time_travel.R
+++ b/R/time_travel.R
@@ -4,7 +4,9 @@
 #' using DuckLake's AT (TIMESTAMP => ...) syntax.
 #'
 #' @param table_name The name of the table to query
-#' @param timestamp A POSIXct timestamp or character string in ISO 8601 format (e.g., "2024-01-15 10:30:00")
+#' @param timestamp A POSIXct timestamp (converted to UTC, which is how
+#'   DuckLake records snapshot times) or character string in ISO 8601 format
+#'   already in UTC (e.g., "2024-01-15 10:30:00")
 #' @param conn Optional DuckDB connection object. If not provided, uses the default ducklake connection.
 #'
 #' @returns A dplyr lazy query object (tbl_lazy) that can be further manipulated with dplyr verbs
@@ -49,13 +51,10 @@ get_ducklake_table_asof <- function(table_name, timestamp, conn = NULL) {
     conn <- get_ducklake_connection()
   }
   
-  # Convert timestamp to character if it's POSIXct
-  if (inherits(timestamp, "POSIXct")) {
-    timestamp_str <- format(timestamp, "%Y-%m-%d %H:%M:%S")
-  } else {
-    timestamp_str <- as.character(timestamp)
-  }
-  
+  # DuckLake reads naive timestamp literals as UTC, so POSIXct values are
+  # rendered in UTC; character input must already be UTC
+  timestamp_str <- format_timestamp(timestamp)
+
   # Add schema prefix if not already present.
   # DuckDB and SQLite use the main. schema; PostgreSQL and MySQL do not.
   if (!grepl("\\.", table_name)) {
@@ -241,7 +240,8 @@ list_table_snapshots <- function(table_name = NULL, ducklake_name = NULL, conn =
 #'
 #' @param table_name The name of the table to restore
 #' @param version Optional snapshot id to restore to (see [list_table_snapshots()])
-#' @param timestamp Optional timestamp to restore to (POSIXct or character)
+#' @param timestamp Optional timestamp to restore to (POSIXct, converted to
+#'   UTC, or character already in UTC)
 #' @param author Optional author to record on the restore snapshot, for the
 #'   audit trail
 #' @param commit_message Optional commit message for the restore snapshot.
@@ -299,12 +299,9 @@ restore_table_version <- function(table_name, version = NULL, timestamp = NULL,
     at_clause <- sprintf("VERSION => %d", as.integer(version))
     restore_point <- sprintf("snapshot %d", as.integer(version))
   } else {
-    # Convert timestamp to character if it's POSIXct
-    if (inherits(timestamp, "POSIXct")) {
-      timestamp_str <- format(timestamp, "%Y-%m-%d %H:%M:%S")
-    } else {
-      timestamp_str <- as.character(timestamp)
-    }
+    # DuckLake reads naive timestamp literals as UTC, so POSIXct values are
+    # rendered in UTC; character input must already be UTC
+    timestamp_str <- format_timestamp(timestamp)
     at_clause <- sprintf("TIMESTAMP => %s", quote_sql(timestamp_str))
     restore_point <- timestamp_str
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -115,7 +115,9 @@ infer_ducklake_name <- function(ducklake_name = NULL,
 #' @noRd
 format_timestamp <- function(x) {
   if (inherits(x, "POSIXct")) {
-    format(x, "%Y-%m-%d %H:%M:%S", tz = "UTC")
+    # %OS6 keeps sub-second precision: flooring to the second can move the
+    # instant before a snapshot taken in the same second
+    format(x, "%Y-%m-%d %H:%M:%OS6", tz = "UTC")
   } else {
     as.character(x)
   }

--- a/man/get_ducklake_table_asof.Rd
+++ b/man/get_ducklake_table_asof.Rd
@@ -9,7 +9,9 @@ get_ducklake_table_asof(table_name, timestamp, conn = NULL)
 \arguments{
 \item{table_name}{The name of the table to query}
 
-\item{timestamp}{A POSIXct timestamp or character string in ISO 8601 format (e.g., "2024-01-15 10:30:00")}
+\item{timestamp}{A POSIXct timestamp (converted to UTC, which is how
+DuckLake records snapshot times) or character string in ISO 8601 format
+already in UTC (e.g., "2024-01-15 10:30:00")}
 
 \item{conn}{Optional DuckDB connection object. If not provided, uses the default ducklake connection.}
 }

--- a/man/restore_table_version.Rd
+++ b/man/restore_table_version.Rd
@@ -18,7 +18,8 @@ restore_table_version(
 
 \item{version}{Optional snapshot id to restore to (see \code{\link[=list_table_snapshots]{list_table_snapshots()}})}
 
-\item{timestamp}{Optional timestamp to restore to (POSIXct or character)}
+\item{timestamp}{Optional timestamp to restore to (POSIXct, converted to
+UTC, or character already in UTC)}
 
 \item{author}{Optional author to record on the restore snapshot, for the
 audit trail}

--- a/tests/testthat/test-time_travel.R
+++ b/tests/testthat/test-time_travel.R
@@ -142,3 +142,28 @@ test_that("time travel functions work with explicit connection", {
   
   cleanup_temp_ducklake(lake)
 })
+
+test_that("naive local POSIXct timestamps resolve as the correct instant", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  on.exit(cleanup_temp_ducklake(lake), add = TRUE)
+
+  create_table(data.frame(id = 1:3, v = c("a", "b", "c")), "utc_asof")
+
+  # Sys.time() carries no tzone attribute; before the UTC fix it was
+  # rendered in local time but read by DuckLake as UTC, shifting the
+  # queried instant by the UTC offset (hours in the past for tz < UTC,
+  # "no snapshot found" here)
+  asof_now <- get_ducklake_table_asof("utc_asof", Sys.time() + 5) |>
+    dplyr::collect()
+  expect_equal(nrow(asof_now), 3)
+
+  # restore_table_version with a bare Sys.time() had the same skew
+  get_ducklake_table("utc_asof") |>
+    dplyr::filter(id != 3) |>
+    replace_table("utc_asof")
+  expect_true(restore_table_version("utc_asof", timestamp = Sys.time()))
+  expect_equal(nrow(dplyr::collect(get_ducklake_table("utc_asof"))), 2)
+})


### PR DESCRIPTION
Fixes the local-time skew flagged during #16/#24: `get_ducklake_table_asof()` and `restore_table_version()` rendered POSIXct timestamps in local time, but DuckLake reads naive literals as UTC — so a bare `Sys.time()` queried an instant shifted by the session's UTC offset (hours in the past on this side of the meridian). Values taken from `list_table_snapshots()$snapshot_time` were unaffected, since they carry a UTC tzone.

Both functions now share the `format_timestamp()` helper the maintenance wrappers use. The helper also keeps microsecond precision now: flooring to the whole second could move an instant before a snapshot taken in the same second, which broke `restore_table_version(timestamp = Sys.time())` immediately after a write.

Regression test covers both functions with naive `Sys.time()` values; docs on the `timestamp` params now state the UTC interpretation.