### PR TITLE
Note catalog VACUUM in routine maintenance guidance

### DIFF
--- a/vignettes/storage-and-backups.Rmd
+++ b/vignettes/storage-and-backups.Rmd
@@ -360,6 +360,11 @@ both mark files as unreferenced, and `cleanup_old_files()` deletes them.
 Expiring a snapshot gives up time travel to it, so choose `older_than` to
 match how far back you need to audit or restore.
 
+One task lives outside DuckLake itself: the catalog database. If you use a
+PostgreSQL or SQLite catalog, occasionally run `VACUUM` there with that
+database's own tooling so metadata queries stay fast. The default DuckDB-file
+catalog does not need this.
+
 ## Maintenance Considerations
 
 When planning backups, coordinate with maintenance operations:


### PR DESCRIPTION
DuckLake's [recommended maintenance docs](https://ducklake.select/docs/stable/duckdb/maintenance/recommended_maintenance) suggest occasionally running `VACUUM` on the catalog database. This was the only item from that page not covered in the package: the inlining, compaction, snapshot-expiration, cleanup, rewrite, and checkpoint workflows all have wrappers, vignette coverage, and tests.

A wrapper isn't warranted since `VACUUM` runs against the catalog database (PostgreSQL/SQLite) with that database's own tooling rather than through the DuckLake connection, so this adds a short note to the Routine Maintenance section of the storage-and-backups vignette instead.

Closes #8