### PR TITLE
Redesign plot_snapshots() as commit log and lake-wide swimlane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,10 @@
 
 * New plotting functions, all requiring the suggested ggplot2 package and
   shown in action in a new "Visualizing Your Lake" vignette:
-  `plot_snapshots()` draws a table's (or the whole lake's) snapshot history
-  as a commit-log style timeline, colored by change type and annotated with
-  snapshot authors and commit messages; `plot_table_changes()` draws the rows
+  `plot_snapshots()` draws a table's snapshot history as a commit-log
+  timeline (snapshots in order, with authors, commit messages, and inline
+  markers for long idle gaps) or, without a table name, the whole lake as a
+  swimlane with one row per table; `plot_table_changes()` draws the rows
   each snapshot inserted, updated, and deleted as diverging bars; and
   `plot_table_files()` draws each table's Parquet file count and size on
   disk.

--- a/R/plot_snapshots.R
+++ b/R/plot_snapshots.R
@@ -1,9 +1,12 @@
 #' Plot the snapshot history of a table or lake
 #'
-#' Draws a table's snapshot history as a commit-log style timeline: one row per
-#' snapshot (newest at top), positioned by snapshot time, colored by the kind
-#' of change, and annotated with the author and commit message where those were
-#' recorded (see [set_snapshot_metadata()] and [commit_transaction()]).
+#' Draws snapshot history in one of two layouts. With a `table_name`, a
+#' commit-log timeline: one row per snapshot (newest at top) on an ordinal
+#' spine, with the timestamp, author, and commit message as aligned text and
+#' long idle stretches marked inline (e.g. "103 days later") instead of
+#' stretching an axis. Without a `table_name`, a lake-wide swimlane: one row
+#' per table, one point per snapshot, evenly spaced in snapshot order, so
+#' active and stale tables read at a glance.
 #'
 #' @param table_name The name of the table to plot. If NULL, plots all
 #'   snapshots in the ducklake.
@@ -19,21 +22,28 @@
 #' Requires the ggplot2 package (listed in Suggests). Snapshot data comes from
 #' [list_table_snapshots()]; each snapshot is classified from its `changes`
 #' column into one of: created, schema change, data change, maintenance, or
-#' other.
+#' other. Authors and commit messages appear where they were recorded (see
+#' [set_snapshot_metadata()] and [commit_transaction()]).
+#'
+#' Both layouts position snapshots by order rather than by clock time, so a
+#' history with months of silence between bursts of activity stays readable.
+#' In the swimlane, snapshots that touch no table (like the initial schema
+#' creation) appear in a `(lake)` lane, and the x axis labels show each
+#' snapshot's date.
 #'
 #' @importFrom dplyr .data
 #'
 #' @examples
 #' \dontrun{
-#' # Plot the snapshot history of a table
+#' # Commit-log timeline of one table's history
 #' plot_snapshots("my_table")
 #'
-#' # Plot every snapshot in the lake
+#' # Swimlane of every table in the lake
 #' plot_snapshots()
 #'
 #' # Customize the result like any ggplot
 #' plot_snapshots("my_table") +
-#'   ggplot2::theme_classic()
+#'   ggplot2::labs(title = "Audit trail")
 #' }
 plot_snapshots <- function(table_name = NULL, ducklake_name = NULL, conn = NULL) {
   if (!requireNamespace("ggplot2", quietly = TRUE)) {
@@ -53,75 +63,239 @@ plot_snapshots <- function(table_name = NULL, ducklake_name = NULL, conn = NULL)
   }
 
   snapshots$change_type <- classify_snapshot_changes(snapshots$changes)
-  # Ascending factor levels put the newest snapshot at the top of the y axis
-  snapshots$snapshot_label <- factor(
-    snapshots$snapshot_id,
-    levels = sort(unique(snapshots$snapshot_id))
-  )
+  snapshots <- snapshots[order(snapshots$snapshot_time, snapshots$snapshot_id), ]
 
-  author <- ifelse(is.na(snapshots$author), "", snapshots$author)
-  msg <- ifelse(is.na(snapshots$commit_message), "", snapshots$commit_message)
-  annotation <- ifelse(
-    author != "" & msg != "",
-    paste0(author, ": ", msg),
-    paste0(author, msg)
-  )
-  snapshots$annotation <- ifelse(annotation == "", NA_character_, annotation)
-
-  # Labels for points in the right 40% of the timeline go on the left of the
-  # point so they don't get clipped at the panel edge
-  time_range <- range(snapshots$snapshot_time)
-  label_cutoff <- time_range[1] + 0.6 * diff(as.numeric(time_range))
-  snapshots$label_hjust <- ifelse(
-    as.numeric(snapshots$snapshot_time) > label_cutoff, 1.15, -0.15
-  )
-
-  # Okabe-Ito hues (colorblind-safe); fixed name-to-color mapping so a
-  # category keeps its color regardless of which categories are present
-  change_colors <- c(
-    "created" = "#0072B2",
-    "schema change" = "#E69F00",
-    "data change" = "#009E73",
-    "maintenance" = "#56B4E9",
-    "other" = "#CC79A7"
-  )
-
-  title <- if (!is.null(table_name)) {
-    sprintf("Snapshot history of %s", table_name)
-  } else if (!is.null(ducklake_name)) {
-    sprintf("Snapshot history of %s", ducklake_name)
+  if (!is.null(table_name)) {
+    plot_snapshot_commit_log(snapshots, table_name)
   } else {
-    "Snapshot history"
+    plot_snapshot_swimlane(snapshots, ducklake_name, conn)
   }
-  subtitle <- sprintf(
+}
+
+# Okabe-Ito hues (colorblind-safe); fixed name-to-color mapping so a
+# category keeps its color regardless of which categories are present
+snapshot_change_colors <- c(
+  "created" = "#0072B2",
+  "schema change" = "#E69F00",
+  "data change" = "#009E73",
+  "maintenance" = "#56B4E9",
+  "other" = "#CC79A7"
+)
+
+snapshot_history_subtitle <- function(snapshots) {
+  sprintf(
     "%d snapshot%s from %s to %s (UTC)",
     nrow(snapshots),
     if (nrow(snapshots) == 1) "" else "s",
     format(min(snapshots$snapshot_time), "%Y-%m-%d %H:%M:%S"),
     format(max(snapshots$snapshot_time), "%Y-%m-%d %H:%M:%S")
   )
+}
 
-  ggplot2::ggplot(
-    snapshots,
-    ggplot2::aes(x = .data$snapshot_time, y = .data$snapshot_label)
-  ) +
-    ggplot2::geom_line(ggplot2::aes(group = 1), color = "grey70") +
+#' Commit-log layout: ordinal spine, time as text, inline gap markers
+#'
+#' @noRd
+plot_snapshot_commit_log <- function(snapshots, table_name) {
+  d <- snapshots
+  d$row <- seq_len(nrow(d))
+  d$id_label <- paste0("#", d$snapshot_id)
+  d$time_label <- format(d$snapshot_time, "%Y-%m-%d %H:%M:%S")
+
+  author <- ifelse(is.na(d$author), "", d$author)
+  msg <- ifelse(is.na(d$commit_message), "", d$commit_message)
+  annotation <- ifelse(
+    author != "" & msg != "",
+    paste0(author, ": ", msg),
+    paste0(author, msg)
+  )
+  d$annotation <- ifelse(annotation == "", NA_character_, annotation)
+
+  # A gap gets an inline marker when it is both long in absolute terms and
+  # an outlier for this table's cadence, so scripted bursts of commits don't
+  # trigger markers while real idle stretches do
+  gap_secs <- diff(as.numeric(d$snapshot_time))
+  gaps <- data.frame(y = utils::head(d$row, -1) + 0.5, secs = gap_secs)
+  gaps <- gaps[
+    gaps$secs > max(4 * stats::median(gap_secs), 3600) & !is.na(gaps$secs),
+  ]
+
+  # Fixed x positions lay the id, timestamp, and annotation out as columns;
+  # the coordinates are arbitrary units within xlim
+  x_spine <- 0
+  x_id <- -0.15
+  x_time <- 0.2
+  x_annotation <- 1.7
+
+  p <- ggplot2::ggplot(d, ggplot2::aes(x = x_spine, y = .data$row)) +
+    ggplot2::annotate(
+      "segment",
+      x = x_spine, xend = x_spine, y = 1, yend = nrow(d),
+      color = "grey80", linewidth = 0.4
+    ) +
     ggplot2::geom_point(ggplot2::aes(color = .data$change_type), size = 3) +
     ggplot2::geom_text(
-      ggplot2::aes(label = .data$annotation, hjust = .data$label_hjust),
-      size = 3, color = "grey30", na.rm = TRUE
+      ggplot2::aes(label = .data$id_label),
+      x = x_id, hjust = 1, size = 3, color = "grey40"
     ) +
-    # Expansion on both sides leaves room for the annotation text
-    ggplot2::scale_x_datetime(expand = ggplot2::expansion(mult = c(0.15, 0.3))) +
-    ggplot2::scale_color_manual(values = change_colors) +
+    ggplot2::geom_text(
+      ggplot2::aes(label = .data$time_label),
+      x = x_time, hjust = 0, size = 3, color = "grey40", family = "mono"
+    ) +
+    ggplot2::geom_text(
+      ggplot2::aes(label = .data$annotation),
+      x = x_annotation, hjust = 0, size = 3, color = "grey20", na.rm = TRUE
+    )
+
+  if (nrow(gaps) > 0) {
+    gaps$label <- paste0(
+      "\u2500\u2500  ", vapply(gaps$secs, format_gap_duration, character(1)),
+      " later  \u2500\u2500"
+    )
+    p <- p + ggplot2::geom_text(
+      data = gaps,
+      ggplot2::aes(x = x_time, y = .data$y, label = .data$label),
+      inherit.aes = FALSE, hjust = 0, size = 2.8, color = "grey55"
+    )
+  }
+
+  p +
+    ggplot2::scale_x_continuous(limits = c(-0.6, 4.5)) +
+    ggplot2::scale_y_continuous(expand = ggplot2::expansion(add = 0.6)) +
+    ggplot2::scale_color_manual(values = snapshot_change_colors, drop = FALSE) +
     ggplot2::labs(
-      title = title,
-      subtitle = subtitle,
-      x = "Snapshot time (UTC)",
-      y = "Snapshot",
+      title = sprintf("Snapshot history of %s", table_name),
+      subtitle = snapshot_history_subtitle(snapshots),
+      color = "Change type"
+    ) +
+    ggplot2::theme_void() +
+    ggplot2::theme(
+      plot.title = ggplot2::element_text(face = "bold"),
+      plot.subtitle = ggplot2::element_text(color = "grey30"),
+      plot.margin = ggplot2::margin(10, 10, 10, 10)
+    )
+}
+
+#' Swimlane layout: one lane per table, points in snapshot order
+#'
+#' @noRd
+plot_snapshot_swimlane <- function(snapshots, ducklake_name, conn) {
+  if (is.null(conn)) {
+    conn <- get_ducklake_connection()
+  }
+  ducklake_name <- infer_ducklake_name(ducklake_name, conn)
+
+  snapshots$order <- seq_len(nrow(snapshots))
+  id_names <- ducklake_table_id_names(ducklake_name, conn)
+  tables <- snapshot_change_tables(snapshots$changes, id_names)
+
+  d <- snapshots[rep(seq_len(nrow(snapshots)), lengths(tables)), ]
+  d$table <- unlist(tables)
+
+  # Lanes ordered by last activity so recently active tables sit on top and
+  # stale ones sink to the bottom
+  last_active <- tapply(d$order, d$table, max)
+  d$table <- factor(d$table, levels = names(sort(last_active)))
+
+  # Ordinal x keeps bursts readable regardless of gaps; date labels at the
+  # breaks carry the calendar information instead of the spacing
+  breaks <- unique(round(pretty(snapshots$order, n = 6)))
+  breaks <- breaks[breaks >= 1 & breaks <= nrow(snapshots)]
+  break_labels <- format(snapshots$snapshot_time[breaks], "%b %d")
+
+  ggplot2::ggplot(d, ggplot2::aes(x = .data$order, y = .data$table)) +
+    ggplot2::geom_point(
+      ggplot2::aes(color = .data$change_type), size = 3, alpha = 0.8
+    ) +
+    ggplot2::scale_x_continuous(breaks = breaks, labels = break_labels) +
+    ggplot2::scale_color_manual(values = snapshot_change_colors, drop = FALSE) +
+    ggplot2::labs(
+      title = sprintf("Snapshot history of %s", ducklake_name),
+      subtitle = snapshot_history_subtitle(snapshots),
+      x = "Snapshot (in order, labeled by date)",
+      y = NULL,
       color = "Change type"
     ) +
     ggplot2::theme_minimal()
+}
+
+#' Human-readable duration for gap markers
+#'
+#' @noRd
+format_gap_duration <- function(secs) {
+  if (secs < 3600) {
+    sprintf("%.0f minutes", secs / 60)
+  } else if (secs < 48 * 3600) {
+    sprintf("%.0f hours", secs / 3600)
+  } else {
+    sprintf("%.0f days", secs / 86400)
+  }
+}
+
+#' Current name for each table id in the lake's metadata catalog
+#'
+#' Returns a named character vector mapping table_id to table_name. Renamed
+#' or replaced tables have several metadata rows per id; the one with the
+#' largest begin_snapshot holds the most recent name.
+#'
+#' @noRd
+ducklake_table_id_names <- function(ducklake_name, conn) {
+  backend <- get_ducklake_backend()
+  metadata_ref <- if (backend %in% c("postgres", "mysql")) {
+    paste0("__ducklake_metadata_", ducklake_name, ".ducklake_table")
+  } else {
+    paste0("__ducklake_metadata_", ducklake_name, ".main.ducklake_table")
+  }
+  tables <- tryCatch(
+    DBI::dbGetQuery(
+      conn,
+      sprintf(
+        "SELECT table_id, table_name FROM %s ORDER BY begin_snapshot",
+        quote_ident(metadata_ref, conn)
+      )
+    ),
+    error = function(e) data.frame(table_id = numeric(0), table_name = character(0))
+  )
+  # Later rows overwrite earlier ones, leaving the most recent name per id
+  stats::setNames(tables$table_name, tables$table_id)[
+    !duplicated(tables$table_id, fromLast = TRUE)
+  ]
+}
+
+#' Attribute each snapshot's changes to table names
+#'
+#' Values under table-related change keys are either qualified names
+#' ("main.fleet", from creates) or numeric table ids ("1", from DML), so ids
+#' go through the metadata map and names get their schema prefix stripped.
+#' Snapshots with no table attribution (like schema creation) fall into a
+#' "(lake)" lane.
+#'
+#' @param changes The list-column from snapshots(): one data.frame of
+#'   key/value pairs per snapshot.
+#' @param id_names Named character vector from ducklake_table_id_names().
+#' @returns A list of character vectors, one per snapshot.
+#' @noRd
+snapshot_change_tables <- function(changes, id_names) {
+  attribute_one <- function(entry) {
+    if (!is.data.frame(entry) || nrow(entry) == 0) {
+      return("(lake)")
+    }
+    keep <- !startsWith(entry$key, "schemas")
+    values <- unique(unlist(entry$value[keep]))
+    values <- values[!is.na(values)]
+    if (length(values) == 0) {
+      return("(lake)")
+    }
+    is_id <- grepl("^[0-9]+$", values)
+    mapped <- character(length(values))
+    mapped[is_id] <- ifelse(
+      values[is_id] %in% names(id_names),
+      id_names[values[is_id]],
+      paste("table", values[is_id])
+    )
+    mapped[!is_id] <- sub("^.*\\.", "", values[!is_id])
+    unique(mapped)
+  }
+  lapply(changes, attribute_one)
 }
 
 #' Classify a snapshot's changes into a change category

--- a/man/plot_snapshots.Rd
+++ b/man/plot_snapshots.Rd
@@ -19,28 +19,38 @@ A ggplot object, which can be further customized with ggplot2
 functions
 }
 \description{
-Draws a table's snapshot history as a commit-log style timeline: one row per
-snapshot (newest at top), positioned by snapshot time, colored by the kind
-of change, and annotated with the author and commit message where those were
-recorded (see \code{\link[=set_snapshot_metadata]{set_snapshot_metadata()}} and \code{\link[=commit_transaction]{commit_transaction()}}).
+Draws snapshot history in one of two layouts. With a \code{table_name}, a
+commit-log timeline: one row per snapshot (newest at top) on an ordinal
+spine, with the timestamp, author, and commit message as aligned text and
+long idle stretches marked inline (e.g. "103 days later") instead of
+stretching an axis. Without a \code{table_name}, a lake-wide swimlane: one row
+per table, one point per snapshot, evenly spaced in snapshot order, so
+active and stale tables read at a glance.
 }
 \details{
 Requires the ggplot2 package (listed in Suggests). Snapshot data comes from
 \code{\link[=list_table_snapshots]{list_table_snapshots()}}; each snapshot is classified from its \code{changes}
 column into one of: created, schema change, data change, maintenance, or
-other.
+other. Authors and commit messages appear where they were recorded (see
+\code{\link[=set_snapshot_metadata]{set_snapshot_metadata()}} and \code{\link[=commit_transaction]{commit_transaction()}}).
+
+Both layouts position snapshots by order rather than by clock time, so a
+history with months of silence between bursts of activity stays readable.
+In the swimlane, snapshots that touch no table (like the initial schema
+creation) appear in a \code{(lake)} lane, and the x axis labels show each
+snapshot's date.
 }
 \examples{
 \dontrun{
-# Plot the snapshot history of a table
+# Commit-log timeline of one table's history
 plot_snapshots("my_table")
 
-# Plot every snapshot in the lake
+# Swimlane of every table in the lake
 plot_snapshots()
 
 # Customize the result like any ggplot
 plot_snapshots("my_table") +
-  ggplot2::theme_classic()
+  ggplot2::labs(title = "Audit trail")
 }
 }
 \seealso{

--- a/tests/testthat/test-plot-snapshots.R
+++ b/tests/testthat/test-plot-snapshots.R
@@ -1,6 +1,6 @@
 # Tests for plot_snapshots() and its changes classifier
 
-test_that("plot_snapshots returns a ggplot with one row per snapshot", {
+test_that("plot_snapshots draws a commit log with one row per snapshot", {
   skip_if_not_installed("duckdb")
   skip_if_not_installed("dplyr")
   skip_if_not_installed("ggplot2")
@@ -23,16 +23,24 @@ test_that("plot_snapshots returns a ggplot with one row per snapshot", {
   expect_s3_class(p, "ggplot")
   snapshots <- list_table_snapshots("plot_snap_1")
   expect_equal(nrow(p$data), nrow(snapshots))
-  expect_true(all(c("change_type", "snapshot_label", "annotation") %in% names(p$data)))
+  expect_true(all(
+    c("change_type", "row", "id_label", "time_label", "annotation") %in%
+      names(p$data)
+  ))
   expect_equal(
     p$data$annotation[p$data$snapshot_id == snapshots$snapshot_id[1]],
     "Analyst: Initial load"
+  )
+  # Newest snapshot gets the highest row so it draws at the top
+  expect_equal(
+    p$data$snapshot_id[which.max(p$data$row)],
+    max(snapshots$snapshot_id)
   )
 
   cleanup_temp_ducklake(lake)
 })
 
-test_that("plot_snapshots works lake-wide with no table_name", {
+test_that("plot_snapshots draws a lake-wide swimlane with a lane per table", {
   skip_if_not_installed("duckdb")
   skip_if_not_installed("dplyr")
   skip_if_not_installed("ggplot2")
@@ -40,11 +48,17 @@ test_that("plot_snapshots works lake-wide with no table_name", {
   lake <- create_temp_ducklake()
 
   create_table(mtcars[1:3, ], "plot_snap_all")
+  create_table(mtcars[1:2, ], "plot_snap_other")
 
   p <- plot_snapshots(ducklake_name = lake$ducklake_name)
 
   expect_s3_class(p, "ggplot")
-  expect_gte(nrow(p$data), 1)
+  expect_true(all(c("table", "order", "change_type") %in% names(p$data)))
+  expect_true(all(
+    c("plot_snap_all", "plot_snap_other") %in% levels(p$data$table)
+  ))
+  # The schema-creation snapshot has no table and lands in the (lake) lane
+  expect_true("(lake)" %in% levels(p$data$table))
 
   cleanup_temp_ducklake(lake)
 })
@@ -91,4 +105,54 @@ test_that("classify_snapshot_changes maps tokens in priority order", {
       "other", "other"
     )
   )
+})
+
+test_that("snapshot_change_tables attributes names, ids, and lake-level changes", {
+  changes <- list(
+    data.frame(key = "schemas_created", value = I(list("main"))),
+    data.frame(
+      key = c("tables_created", "inlined_insert"),
+      value = I(list("main.fleet", "1"))
+    ),
+    data.frame(key = "inlined_insert", value = I(list("1"))),
+    data.frame(key = "tables_inserted_into", value = I(list("99")))
+  )
+  id_names <- c("1" = "fleet", "2" = "crew")
+
+  result <- snapshot_change_tables(changes, id_names)
+
+  expect_equal(result[[1]], "(lake)")
+  expect_equal(result[[2]], "fleet")
+  expect_equal(result[[3]], "fleet")
+  # Unknown ids keep a placeholder lane rather than being dropped
+  expect_equal(result[[4]], "table 99")
+})
+
+test_that("format_gap_duration picks sensible units", {
+  expect_equal(format_gap_duration(45 * 60), "45 minutes")
+  expect_equal(format_gap_duration(18 * 3600), "18 hours")
+  expect_equal(format_gap_duration(103 * 86400), "103 days")
+})
+
+test_that("commit log marks large gaps between snapshots", {
+  skip_if_not_installed("ggplot2")
+
+  base <- as.POSIXct("2026-03-10 09:00:00", tz = "UTC")
+  snapshots <- data.frame(
+    snapshot_id = 1:4,
+    snapshot_time = base + c(0, 60, 120, 103 * 86400),
+    author = NA_character_,
+    commit_message = NA_character_
+  )
+  snapshots$changes <- I(as.list(rep("inlined_insert, 1", 4)))
+  snapshots$change_type <- classify_snapshot_changes(snapshots$changes)
+
+  p <- plot_snapshot_commit_log(snapshots, "gappy")
+
+  gap_layer_data <- lapply(p$layers, function(l) l$data)
+  gap_labels <- unlist(lapply(gap_layer_data, function(d) {
+    if (is.data.frame(d) && "label" %in% names(d)) d$label else NULL
+  }))
+  expect_length(gap_labels, 1)
+  expect_match(gap_labels, "103 days later")
 })

--- a/vignettes/visualizing-your-lake.Rmd
+++ b/vignettes/visualizing-your-lake.Rmd
@@ -121,10 +121,14 @@ list_table_snapshots("fleet") |>
 plot_snapshots("fleet")
 ```
 
-Reading it like a git log: the newest snapshot is at the top, the horizontal
-position shows when each change landed, and the color shows whether the
-snapshot created the table, changed data, changed the schema, or was
-maintenance activity (like flushing inlined data or compacting files).
+Reading it like a git log: the newest snapshot is at the top, each row shows
+the snapshot's timestamp, author, and commit message, and the color shows
+whether the snapshot created the table, changed data, changed the schema, or
+was maintenance activity (like flushing inlined data or compacting files).
+Snapshots are spaced evenly by order rather than by clock time, so a table
+that sat untouched for months stays readable: a long idle stretch shows up
+as an inline marker (like "103 days later") instead of stretching the whole
+plot.
 
 ## How Much Changed
 
@@ -136,15 +140,6 @@ inserted or updated above the axis, rows deleted below it.
 
 ```{r plot-changes}
 plot_table_changes("fleet")
-```
-
-## Plotting the Whole Lake
-
-Calling `plot_snapshots()` without a table name shows every snapshot in the
-lake, which is useful for a quick health check of overall activity:
-
-```{r plot-lake}
-plot_snapshots()
 ```
 
 ## How the Data Is Stored
@@ -202,14 +197,33 @@ delete-file share mean it is time for the compaction tools covered in
 `vignette("storage-and-backups")`, like `merge_adjacent_files()` and
 `rewrite_data_files()`.
 
+## Plotting the Whole Lake
+
+With two tables in the lake, we can step back and look at everything at
+once. Calling `plot_snapshots()` without a table name switches to a swimlane
+view: one row per table, one point per snapshot, with recently active tables
+at the top. It answers a different question than the single-table timeline
+-- not "what happened to this table" but "which tables are active, and what
+kind of churn does each one see":
+
+```{r plot-lake}
+plot_snapshots()
+```
+
+Snapshots that don't belong to any table, like the initial schema creation,
+appear in a `(lake)` lane. As in the timeline, points are spaced by order
+rather than clock time; the x axis labels show each snapshot's date.
+
 ## Customizing the Plots
 
 Each function returns a regular ggplot object, so you can restyle it like
-any other plot:
+any other plot. (The single-table timeline draws on a blank canvas, so it is
+best customized with `labs()` and `theme()` tweaks rather than a full theme
+swap like `theme_classic()`, which would bring back axes that have no
+meaning there.)
 
 ```{r plot-custom}
 plot_snapshots("fleet") +
-  ggplot2::theme_classic() +
   ggplot2::labs(title = "Fleet table audit trail")
 ```
 


### PR DESCRIPTION
The linear time axis in `plot_snapshots()` collapsed under realistic histories: one long idle stretch between working sessions consumed most of the axis and crushed each session's snapshots into an unreadable cluster, dragging their labels with them. Both layouts now position snapshots by order instead of clock time, so any gap distribution stays readable.

**Per-table view: commit-log timeline.** One row per snapshot (newest at top) on an ordinal spine, with the timestamp, author, and commit message as aligned text columns. Idle stretches get an inline marker ("── 103 days later ──") when a gap is both over an hour and more than 4× the table's median gap, so scripted bursts of commits don't trigger markers while real pauses do.

**Lake-wide view: swimlane.** One lane per table (ordered by last activity, stale tables at the bottom), one point per snapshot, evenly spaced by order with dates as the x-axis labels. Each snapshot is attributed to its tables from the `changes` column: qualified names directly, bare numeric DML ids through the metadata catalog's table id map (which also resolves renames). Schema-level snapshots land in a `(lake)` lane.

The vignette's whole-lake section moved after the storage section so the swimlane demos with three lanes (including a maintenance snapshot from the flush), and the customization example no longer suggests `theme_classic()`, which would resurrect meaningless axes on the commit log's blank canvas.

No new dependencies; ggplot2 remains the only (suggested) plotting requirement.