### PR TITLE
Harden plot edge cases

### DIFF
--- a/R/plot_snapshots.R
+++ b/R/plot_snapshots.R
@@ -101,8 +101,9 @@ plot_snapshot_commit_log <- function(snapshots, table_name) {
   d$id_label <- paste0("#", d$snapshot_id)
   d$time_label <- format(d$snapshot_time, "%Y-%m-%d %H:%M:%S")
 
-  author <- ifelse(is.na(d$author), "", d$author)
-  msg <- ifelse(is.na(d$commit_message), "", d$commit_message)
+  # snapshots() may omit author/commit_message depending on DuckLake version
+  author <- if (is.null(d$author)) rep("", nrow(d)) else ifelse(is.na(d$author), "", d$author)
+  msg <- if (is.null(d$commit_message)) rep("", nrow(d)) else ifelse(is.na(d$commit_message), "", d$commit_message)
   annotation <- ifelse(
     author != "" & msg != "",
     paste0(author, ": ", msg),
@@ -115,9 +116,13 @@ plot_snapshot_commit_log <- function(snapshots, table_name) {
   # trigger markers while real idle stretches do
   gap_secs <- diff(as.numeric(d$snapshot_time))
   gaps <- data.frame(y = utils::head(d$row, -1) + 0.5, secs = gap_secs)
-  gaps <- gaps[
-    gaps$secs > max(4 * stats::median(gap_secs), 3600) & !is.na(gaps$secs),
-  ]
+  gaps <- gaps[!is.na(gaps$secs), , drop = FALSE]
+  if (nrow(gaps) > 0) {
+    gaps <- gaps[
+      gaps$secs > max(4 * stats::median(gaps$secs), 3600), ,
+      drop = FALSE
+    ]
+  }
 
   # Fixed x positions lay the id, timestamp, and annotation out as columns;
   # the coordinates are arbitrary units within xlim

--- a/R/plot_table_files.R
+++ b/R/plot_table_files.R
@@ -53,6 +53,11 @@ plot_table_files <- function(ducklake_name = NULL, conn = NULL) {
     ))
   }
 
+  # Fully inlined tables can report NA counts/sizes; treat as zero on disk
+  for (col in c("file_count", "file_size_bytes", "delete_file_size_bytes")) {
+    info[[col]][is.na(info[[col]])] <- 0
+  }
+
   # Ascending levels put the largest table at the top of the y axis
   info$total_bytes <- info$file_size_bytes + info$delete_file_size_bytes
   table_levels <- info$table_name[order(info$total_bytes)]

--- a/tests/testthat/test-plot-snapshots.R
+++ b/tests/testthat/test-plot-snapshots.R
@@ -156,3 +156,19 @@ test_that("commit log marks large gaps between snapshots", {
   expect_length(gap_labels, 1)
   expect_match(gap_labels, "103 days later")
 })
+
+test_that("commit log handles a single snapshot without metadata columns", {
+  skip_if_not_installed("ggplot2")
+
+  snapshots <- data.frame(
+    snapshot_id = 1,
+    snapshot_time = as.POSIXct("2026-03-10 09:00:00", tz = "UTC")
+  )
+  snapshots$changes <- I(list("tables_created, main.solo"))
+  snapshots$change_type <- classify_snapshot_changes(snapshots$changes)
+
+  expect_no_warning(p <- plot_snapshot_commit_log(snapshots, "solo"))
+
+  expect_s3_class(p, "ggplot")
+  expect_true(all(is.na(p$data$annotation)))
+})

--- a/tests/testthat/test-plot-table-files.R
+++ b/tests/testthat/test-plot-table-files.R
@@ -38,3 +38,26 @@ test_that("format_bytes produces readable sizes", {
     c("0 B", "512 B", "2.9 kB", "20 kB", "5.2 MB", "1.4 GB", NA)
   )
 })
+
+test_that("plot_table_files treats NA file stats as zero", {
+  skip_if_not_installed("ggplot2")
+
+  local_mocked_bindings(
+    get_ducklake_connection = function() NULL,
+    infer_ducklake_name = function(ducklake_name, conn) "mock_lake",
+    get_table_info = function(...) {
+      data.frame(
+        table_name = c("inlined_tbl", "on_disk"),
+        file_count = c(NA, 2),
+        file_size_bytes = c(NA, 1000),
+        delete_file_count = c(NA, 0),
+        delete_file_size_bytes = c(NA, 0)
+      )
+    }
+  )
+
+  p <- plot_table_files()
+
+  expect_s3_class(p, "ggplot")
+  expect_equal(sum(p$data$bytes), 1000)
+})


### PR DESCRIPTION
Follow-up to #29. The plot functions now handle three edge cases cleanly:

- `plot_snapshots()` no longer errors when the `snapshots()` result lacks `author`/`commit_message` columns (possible depending on DuckLake version), and a single-snapshot history renders without gap-marker artifacts.
- `plot_table_files()` treats NA file counts/sizes (fully inlined tables) as zero bytes on disk instead of propagating NA to the axis and subtitle.

Tests cover each guard directly, using mocked table stats where a live lake can't produce the edge case.