### PR TITLE
Harden table operations and snapshot metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,17 @@
   file counts and sizes) from the DuckLake catalog, wrapping DuckLake's
   `ducklake_table_info()` function.
 
+* `replace_table()` now runs its drop and create as one transaction, so a
+  failed create no longer leaves the table dropped. When the caller has
+  already opened a transaction, `replace_table()` defers to it as before.
+
+* `set_snapshot_metadata()` now validates `ducklake_name` like the rest of
+  the package, and resolves the catalog backend from that name instead of
+  the current database.
+
+* `create_table()` no longer leaves a temporary view registered on the
+  shared connection when the CREATE statement fails.
+
 * New targeted maintenance wrappers complement `checkpoint_ducklake()`:
   `expire_snapshots()` (with `older_than`, `versions`, and `dry_run`),
   `merge_adjacent_files()`, `cleanup_old_files()`, `delete_orphaned_files()`,

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,10 @@
 * `create_table()` no longer leaves a temporary view registered on the
   shared connection when the CREATE statement fails.
 
+* `replace_table(.quiet = FALSE)` reports progress via messages (cli) rather
+  than printing to the console, so it can be suppressed and captured like
+  the rest of the package's output.
+
 * New targeted maintenance wrappers complement `checkpoint_ducklake()`:
   `expire_snapshots()` (with `older_than`, `versions`, and `dry_run`),
   `merge_adjacent_files()`, `cleanup_old_files()`, `delete_orphaned_files()`,

--- a/R/create_table.R
+++ b/R/create_table.R
@@ -46,19 +46,22 @@ create_table <- function(data_source, table_name) {
       )
     }
 
-    # Register the data.frame as a temporary view in DuckDB
+    # Register the data.frame as a temporary view in DuckDB; unregister on
+    # exit so a failed CREATE doesn't leave the view behind on the shared
+    # connection
     temp_view_name <- paste0("__temp_view_", gsub("[^a-zA-Z0-9]", "_", table_name))
     duckdb::duckdb_register(get_ducklake_connection(), temp_view_name, data_source)
-    
+    on.exit(
+      duckdb::duckdb_unregister(get_ducklake_connection(), temp_view_name),
+      add = TRUE
+    )
+
     # Create the table from the temporary view
     db_execute(sprintf(
       "CREATE TABLE %s AS SELECT * FROM %s;",
       quote_ident(table_name), quote_ident(temp_view_name)
     ))
-    
-    # Unregister the temporary view
-    duckdb::duckdb_unregister(get_ducklake_connection(), temp_view_name)
-    
+
     return(invisible(NULL))
   }
   

--- a/R/replace_table.R
+++ b/R/replace_table.R
@@ -12,12 +12,16 @@
 #' This function is designed for schema changes or bulk transformations that should
 #' create a new versioned snapshot. It:
 #' 1. Collects the transformed data
-#' 2. Drops the existing table  
+#' 2. Drops the existing table
 #' 3. Creates a new table with the updated schema/data
-#' 
-#' All operations happen within the current transaction context. Use
-#' `begin_transaction()` and `commit_transaction()` to ensure proper versioning.
-#' 
+#'
+#' The drop and create run atomically: when no transaction is open,
+#' `replace_table()` wraps them in one of its own, so a failed create never
+#' leaves the table dropped. Wrap the call in [with_transaction()] (or
+#' `begin_transaction()`/`commit_transaction()`) when you want to record an
+#' author and commit message on the snapshot, or to group the replacement
+#' with other changes.
+#'
 #' **When to use replace_table():**
 #' - **Adding new columns** - DuckLake UPDATE cannot add columns; use replace_table()
 #' - **Removing columns** - Restructure schema with select()
@@ -33,8 +37,7 @@
 #' 
 #' @examples
 #' \dontrun{
-#' # Add new derived columns with versioning
-#' begin_transaction()
+#' # Add new derived columns (atomic on its own; creates a new snapshot)
 #' get_ducklake_table("adsl") |>
 #'   mutate(
 #'     AGE65FL = if_else(AGE >= 65, "Y", "N"),
@@ -45,14 +48,15 @@
 #'     )
 #'   ) |>
 #'   replace_table("adsl")
-#' commit_transaction()
-#' 
-#' # Remove columns and create new snapshot
-#' begin_transaction()
-#' get_ducklake_table("adsl") |>
-#'   select(-AGE65FL, -AGECAT) |>
-#'   replace_table("adsl")
-#' commit_transaction()
+#'
+#' # Wrap in with_transaction() to record audit metadata on the snapshot
+#' with_transaction(
+#'   get_ducklake_table("adsl") |>
+#'     select(-AGE65FL, -AGECAT) |>
+#'     replace_table("adsl"),
+#'   author = "Data Engineer",
+#'   commit_message = "Drop derived age columns"
+#' )
 #' }
 replace_table <- function(.data, table_name, .quiet = TRUE) {
 

--- a/R/replace_table.R
+++ b/R/replace_table.R
@@ -68,18 +68,40 @@ replace_table <- function(.data, table_name, .quiet = TRUE) {
     cat("Collected", nrow(new_data), "rows with", ncol(new_data), "columns\n")
   }
   
+  # The drop and create must land together: outside a transaction they
+  # autocommit separately, so a failed create would leave the table gone.
+  # When the caller already opened a transaction, they own the
+  # commit/rollback decision.
+  conn <- get_ducklake_connection()
+  own_txn <- !in_transaction(conn)
+  committed <- FALSE
+  if (own_txn) {
+    DBI::dbExecute(conn, "BEGIN TRANSACTION;")
+    on.exit(
+      if (!committed) {
+        tryCatch(DBI::dbExecute(conn, "ROLLBACK;"), error = function(e) NULL)
+      },
+      add = TRUE
+    )
+  }
+
   # Drop the existing table
   if (!.quiet) cat("Dropping existing table...\n")
   drop_sql <- sprintf("DROP TABLE IF EXISTS %s", quote_ident(table_name))
   db_execute(drop_sql)
-  
+
   # Create the new table
   if (!.quiet) cat("Creating new table...\n")
   create_table(new_data, table_name)
-  
+
+  if (own_txn) {
+    DBI::dbExecute(conn, "COMMIT;")
+    committed <- TRUE
+  }
+
   if (!.quiet) {
     cat("Table", table_name, "successfully replaced\n")
   }
-  
+
   invisible(NULL)
 }

--- a/R/replace_table.R
+++ b/R/replace_table.R
@@ -55,19 +55,20 @@
 #' commit_transaction()
 #' }
 replace_table <- function(.data, table_name, .quiet = TRUE) {
-  
+
   if (!.quiet) {
-    cat("=== Replacing table:", table_name, "===\n")
+    cli::cli_inform("Replacing table {.val {table_name}}...")
   }
-  
+
   # Collect the transformed data
-  if (!.quiet) cat("Collecting transformed data...\n")
   new_data <- dplyr::collect(.data)
-  
+
   if (!.quiet) {
-    cat("Collected", nrow(new_data), "rows with", ncol(new_data), "columns\n")
+    cli::cli_inform(
+      "Collected {nrow(new_data)} row{?s} with {ncol(new_data)} column{?s}."
+    )
   }
-  
+
   # The drop and create must land together: outside a transaction they
   # autocommit separately, so a failed create would leave the table gone.
   # When the caller already opened a transaction, they own the
@@ -86,12 +87,10 @@ replace_table <- function(.data, table_name, .quiet = TRUE) {
   }
 
   # Drop the existing table
-  if (!.quiet) cat("Dropping existing table...\n")
   drop_sql <- sprintf("DROP TABLE IF EXISTS %s", quote_ident(table_name))
   db_execute(drop_sql)
 
   # Create the new table
-  if (!.quiet) cat("Creating new table...\n")
   create_table(new_data, table_name)
 
   if (own_txn) {
@@ -100,7 +99,7 @@ replace_table <- function(.data, table_name, .quiet = TRUE) {
   }
 
   if (!.quiet) {
-    cat("Table", table_name, "successfully replaced\n")
+    cli::cli_inform("Table {.val {table_name}} successfully replaced.")
   }
 
   invisible(NULL)

--- a/R/transactions.R
+++ b/R/transactions.R
@@ -107,19 +107,15 @@ commit_transaction <- function(
     if (db_ok) {
       # Build the CALL set_commit_message() statement
       # Signature: CALL ducklake.set_commit_message(author, message, extra_info => '...')
-      author_sql <- if (!is.null(author)) {
-        sprintf("'%s'", gsub("'", "''", author))
-      } else {
-        "NULL"
-      }
+      author_sql <- if (!is.null(author)) quote_sql(author) else "NULL"
       message_sql <- if (!is.null(commit_message)) {
-        sprintf("'%s'", gsub("'", "''", commit_message))
+        quote_sql(commit_message)
       } else {
         "NULL"
       }
 
       if (!is.null(commit_extra_info)) {
-        extra_sql <- sprintf("'%s'", gsub("'", "''", commit_extra_info))
+        extra_sql <- quote_sql(commit_extra_info)
         call_sql <- sprintf(
           "CALL %s.set_commit_message(%s, %s, extra_info => %s)",
           current_db,
@@ -198,6 +194,7 @@ set_snapshot_metadata <- function(
   if (is.null(conn)) {
     conn <- get_ducklake_connection()
   }
+  check_identifier(ducklake_name)
 
   if (
     is.null(author) && is.null(commit_message) && is.null(commit_extra_info)
@@ -223,7 +220,7 @@ set_snapshot_metadata <- function(
   }
 
   # Qualify metadata table names based on backend
-  backend <- get_ducklake_backend()
+  backend <- get_ducklake_backend(ducklake_name)
   meta_db <- paste0("__ducklake_metadata_", ducklake_name)
   if (backend %in% c("postgres", "mysql")) {
     changes_ref <- sprintf("\"%s\".ducklake_snapshot_changes", meta_db)

--- a/R/utils.R
+++ b/R/utils.R
@@ -123,6 +123,28 @@ format_timestamp <- function(x) {
   }
 }
 
+#' Test whether the connection has an open transaction
+#'
+#' DuckDB aborts an open transaction when any statement in it fails, so
+#' probing with a BEGIN would poison a caller's transaction. Instead compare
+#' `current_transaction_id()` across two statements: in autocommit mode each
+#' statement runs in its own transaction so the id advances, while inside an
+#' open transaction it stays the same.
+#'
+#' @param conn A DBI connection.
+#' @returns `TRUE` if a transaction is open, otherwise `FALSE`.
+#' @noRd
+in_transaction <- function(conn = get_ducklake_connection()) {
+  ids <- tryCatch(
+    c(
+      DBI::dbGetQuery(conn, "SELECT current_transaction_id() AS id")$id,
+      DBI::dbGetQuery(conn, "SELECT current_transaction_id() AS id")$id
+    ),
+    error = function(e) NULL
+  )
+  length(ids) == 2 && ids[1] == ids[2]
+}
+
 #' Quote a value as a SQL string literal
 #'
 #' Wraps `x` in single quotes and doubles any embedded single quotes.

--- a/man/replace_table.Rd
+++ b/man/replace_table.Rd
@@ -28,8 +28,12 @@ create a new versioned snapshot. It:
 \item Creates a new table with the updated schema/data
 }
 
-All operations happen within the current transaction context. Use
-\code{begin_transaction()} and \code{commit_transaction()} to ensure proper versioning.
+The drop and create run atomically: when no transaction is open,
+\code{replace_table()} wraps them in one of its own, so a failed create never
+leaves the table dropped. Wrap the call in \code{\link[=with_transaction]{with_transaction()}} (or
+\code{begin_transaction()}/\code{commit_transaction()}) when you want to record an
+author and commit message on the snapshot, or to group the replacement
+with other changes.
 
 \strong{When to use replace_table():}
 \itemize{
@@ -50,8 +54,7 @@ change is available for time travel.
 }
 \examples{
 \dontrun{
-# Add new derived columns with versioning
-begin_transaction()
+# Add new derived columns (atomic on its own; creates a new snapshot)
 get_ducklake_table("adsl") |>
   mutate(
     AGE65FL = if_else(AGE >= 65, "Y", "N"),
@@ -62,14 +65,15 @@ get_ducklake_table("adsl") |>
     )
   ) |>
   replace_table("adsl")
-commit_transaction()
 
-# Remove columns and create new snapshot
-begin_transaction()
-get_ducklake_table("adsl") |>
-  select(-AGE65FL, -AGECAT) |>
-  replace_table("adsl")
-commit_transaction()
+# Wrap in with_transaction() to record audit metadata on the snapshot
+with_transaction(
+  get_ducklake_table("adsl") |>
+    select(-AGE65FL, -AGECAT) |>
+    replace_table("adsl"),
+  author = "Data Engineer",
+  commit_message = "Drop derived age columns"
+)
 }
 }
 \seealso{

--- a/tests/testthat/test-install-ducklake.R
+++ b/tests/testthat/test-install-ducklake.R
@@ -1,0 +1,35 @@
+# Tests for install_ducklake()
+
+test_that("install_ducklake issues INSTALL statements for backends", {
+  executed <- character()
+  local_mocked_bindings(
+    db_execute = function(sql, ...) {
+      executed <<- c(executed, sql)
+      invisible(NULL)
+    }
+  )
+
+  suppressMessages(install_ducklake(backend = c("sqlite", "mysql")))
+
+  expect_equal(
+    executed,
+    c("INSTALL ducklake;", "INSTALL sqlite;", "INSTALL mysql;")
+  )
+})
+
+test_that("install_ducklake aborts on DuckDB engines older than 1.5.1", {
+  local_mocked_bindings(
+    duckdb_version_at_least = function(version, minimum) FALSE
+  )
+
+  expect_error(install_ducklake(), "requires DuckDB version 1.5.1")
+})
+
+test_that("install_ducklake rejects unknown backends", {
+  local_mocked_bindings(db_execute = function(sql, ...) invisible(NULL))
+
+  expect_error(
+    suppressMessages(install_ducklake(backend = "oracle")),
+    "should be one of"
+  )
+})

--- a/tests/testthat/test-quack.R
+++ b/tests/testthat/test-quack.R
@@ -136,3 +136,40 @@ test_that("quack_serve and quack_query complete a live round trip", {
     }
   )
 })
+
+test_that("install_quack installs and optionally loads the extension", {
+  executed <- character()
+  local_mocked_bindings(
+    check_quack_version = function(...) invisible(TRUE),
+    db_execute = function(sql, ...) {
+      executed <<- c(executed, sql)
+      invisible(NULL)
+    }
+  )
+
+  suppressMessages(install_quack())
+  expect_equal(executed, c("INSTALL quack;", "LOAD quack;"))
+
+  executed <- character()
+  suppressMessages(install_quack(load = FALSE))
+  expect_equal(executed, "INSTALL quack;")
+})
+
+test_that("detach_quack removes the catalog and ignores unknown names", {
+  skip_if_not_installed("duckdb")
+
+  conn <- get_ducklake_connection()
+  DBI::dbExecute(conn, "ATTACH ':memory:' AS quack_detach_test;")
+
+  detach_quack("quack_detach_test")
+
+  attached <- DBI::dbGetQuery(
+    conn,
+    "SELECT database_name FROM duckdb_databases();"
+  )$database_name
+  expect_false("quack_detach_test" %in% attached)
+
+  # Unknown names and NULL are silent no-ops
+  expect_no_error(detach_quack("no_such_catalog"))
+  expect_no_error(detach_quack())
+})

--- a/tests/testthat/test-snapshot-metadata.R
+++ b/tests/testthat/test-snapshot-metadata.R
@@ -157,3 +157,10 @@ test_that("set_snapshot_metadata warns when no metadata provided", {
 
   cleanup_temp_ducklake(lake)
 })
+
+test_that("set_snapshot_metadata validates the ducklake name", {
+  expect_error(
+    set_snapshot_metadata('bad"name', author = "x"),
+    "simple identifier"
+  )
+})

--- a/tests/testthat/test-table-operations.R
+++ b/tests/testthat/test-table-operations.R
@@ -193,3 +193,48 @@ test_that("table operations work in transaction context", {
   
   cleanup_temp_ducklake(lake)
 })
+
+test_that("replace_table keeps the original table when the create fails", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  create_table(mtcars[1:5, ], "replace_atomic")
+
+  local_mocked_bindings(
+    create_table = function(...) stop("simulated create failure")
+  )
+  expect_error(
+    get_ducklake_table("replace_atomic") |>
+      dplyr::filter(mpg > 0) |>
+      replace_table("replace_atomic"),
+    "simulated create failure"
+  )
+
+  result <- get_ducklake_table("replace_atomic") |> dplyr::collect()
+  expect_equal(nrow(result), 5)
+
+  cleanup_temp_ducklake(lake)
+})
+
+test_that("create_table unregisters its temp view when the CREATE fails", {
+  skip_if_not_installed("duckdb")
+
+  lake <- create_temp_ducklake()
+
+  local_mocked_bindings(
+    db_execute = function(sql, ...) stop("simulated create failure")
+  )
+  expect_error(
+    create_table(mtcars, "view_leak_check"),
+    "simulated create failure"
+  )
+
+  views <- DBI::dbGetQuery(
+    lake$conn,
+    "SELECT view_name FROM duckdb_views() WHERE view_name = '__temp_view_view_leak_check'"
+  )
+  expect_equal(nrow(views), 0)
+
+  cleanup_temp_ducklake(lake)
+})

--- a/tests/testthat/test-table-operations.R
+++ b/tests/testthat/test-table-operations.R
@@ -135,36 +135,20 @@ test_that("replace_table respects .quiet parameter", {
   })
   
   # Test with .quiet = FALSE
-  output_verbose <- capture.output({
-    with_transaction({
-      get_ducklake_table("test_replace_quiet") |>
-        dplyr::mutate(new_col = "added") |>
-        replace_table("test_replace_quiet", .quiet = FALSE)
-    })
-  })
-  
-  # Should have messages
-  expect_true(length(output_verbose) > 0)
-  
-  # Reset table
-  with_transaction({
+  expect_message(
+    get_ducklake_table("test_replace_quiet") |>
+      dplyr::mutate(new_col = "added") |>
+      replace_table("test_replace_quiet", .quiet = FALSE),
+    "Replacing table"
+  )
+
+  # Test with .quiet = TRUE
+  expect_no_message(
     get_ducklake_table("test_replace_quiet") |>
       dplyr::select(id, value) |>
       replace_table("test_replace_quiet", .quiet = TRUE)
-  })
-  
-  # Test with .quiet = TRUE
-  output_quiet <- capture.output({
-    with_transaction({
-      get_ducklake_table("test_replace_quiet") |>
-        dplyr::mutate(new_col = "added") |>
-        replace_table("test_replace_quiet", .quiet = TRUE)
-    })
-  })
-  
-  # Should have less output
-  expect_true(length(output_quiet) < length(output_verbose))
-  
+  )
+
   cleanup_temp_ducklake(lake)
 })
 


### PR DESCRIPTION
Robustness fixes from a review of the package against DuckLake 1.0. **Merge order: this PR first, then #32 (ducklake-1.0-coverage), then #33 (cran-prep)** — they're stacked so each merges cleanly.

- `replace_table()` now runs its drop and create as one transaction, so a failed create no longer leaves the table dropped. A new internal `in_transaction()` helper detects an open transaction by comparing `current_transaction_id()` across two statements — a trial `BEGIN` can't be used because a failed statement aborts an open DuckDB transaction, which would poison a caller's `with_transaction()`.
- `set_snapshot_metadata()` validates `ducklake_name` with `check_identifier()` like every other consumer (it was interpolated into SQL unvalidated), and resolves the catalog backend from that name rather than the current database.
- `create_table()` unregisters its temporary view via `on.exit()`, so a failed CREATE no longer leaks the view on the shared connection.
- `commit_transaction()` uses `quote_sql()` instead of hand-rolled escaping.
- `replace_table(.quiet = FALSE)` reports progress via cli messages instead of `cat()`, and its docs now describe the built-in atomicity (transactions are for audit metadata and grouping, not safety).
- New tests for `install_ducklake()`, `install_quack()`, and `detach_quack()`, which previously had none, plus tests that force mid-operation failures to verify the atomicity and cleanup behavior.