### PR TITLE
Prepare for CRAN submission

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^\.github$
 ^data-raw$
 ^\.claude$
+^cran-comments\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,22 +1,25 @@
 Package: ducklake
-Title: Interact with DuckLake from R
+Title: Interact with 'DuckLake' from R
 Version: 0.4.0.9000
 Authors@R: c(
     person("Travis", "Gerke", , "tgerke@mail.harvard.edu", role = c("aut", "cre")),
     person("Stefan", "Linner", role = "ctb"),
     person("Javier", "Orraca-Deatcu", role = "ctb")
   )
-Description: A tidyverse-friendly interface to DuckLake, the DuckDB
-    lakehouse format. Attach versioned data lakes from R and work with
-    them using familiar dplyr verbs, with support for ACID transactions,
-    time travel queries, snapshot audit trails, data inlining, encrypted
-    storage, multiple catalog backends (DuckDB, PostgreSQL, SQLite,
-    MySQL), and remote access over DuckDB's Quack protocol.
+Description: A tidyverse-friendly interface to 'DuckLake'
+    <https://ducklake.select/>, the 'DuckDB' lakehouse format. Attach
+    versioned data lakes from R and work with them using familiar 'dplyr'
+    verbs, with support for ACID transactions, time travel queries,
+    snapshot audit trails, data inlining, encrypted storage, multiple
+    catalog backends ('DuckDB', 'PostgreSQL', 'SQLite', 'MySQL'), and
+    remote access over 'DuckDB's 'Quack' protocol.
 License: MIT + file LICENSE
 URL: https://tgerke.github.io/ducklake-r/, https://github.com/tgerke/ducklake-r
 BugReports: https://github.com/tgerke/ducklake-r/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
+Depends:
+    R (>= 4.1)
 Imports:
     cli,
     DBI,

--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,11 @@
   than printing to the console, so it can be suppressed and captured like
   the rest of the package's output.
 
+* The package now declares R (>= 4.1) explicitly (the tests and examples use
+  the base pipe), and is prepared for CRAN: extension-dependent tests skip
+  on CRAN, and vignettes evaluate only where the ducklake DuckDB extension
+  can be loaded.
+
 * New targeted maintenance wrappers complement `checkpoint_ducklake()`:
   `expire_snapshots()` (with `older_than`, `versions`, and `dry_run`),
   `merge_adjacent_files()`, `cleanup_old_files()`, `delete_orphaned_files()`,

--- a/README.Rmd
+++ b/README.Rmd
@@ -20,7 +20,7 @@ knitr::opts_knit$set(root.dir = tempdir())
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![R-CMD-check](https://github.com/tgerke/ducklake-r/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/tgerke/ducklake-r/actions/workflows/R-CMD-check.yaml)
 [![pkgdown](https://github.com/tgerke/ducklake-r/workflows/pkgdown/badge.svg)](https://github.com/tgerke/ducklake-r/actions)
-[![codecov](https://codecov.io/gh/tgerke/ducklake-r/branch/main/graph/badge.svg)](https://codecov.io/gh/tgerke/ducklake-r)
+[![codecov](https://codecov.io/gh/tgerke/ducklake-r/branch/main/graph/badge.svg)](https://app.codecov.io/gh/tgerke/ducklake-r)
 <!-- badges: end -->
 
 ducklake is an R package that brings versioned data lake infrastructure to data-intensive workflows. Built on [DuckDB](https://r.duckdb.org/index.html) and [DuckLake](https://ducklake.select/docs/stable/duckdb/introduction.html), it provides ACID transactions, automatic versioning, time travel queries, and complete audit trails.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![R-CMD-check](https://github.com/tgerke/ducklake-r/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/tgerke/ducklake-r/actions/workflows/R-CMD-check.yaml)
 [![pkgdown](https://github.com/tgerke/ducklake-r/workflows/pkgdown/badge.svg)](https://github.com/tgerke/ducklake-r/actions)
-[![codecov](https://codecov.io/gh/tgerke/ducklake-r/branch/main/graph/badge.svg)](https://codecov.io/gh/tgerke/ducklake-r)
+[![codecov](https://codecov.io/gh/tgerke/ducklake-r/branch/main/graph/badge.svg)](https://app.codecov.io/gh/tgerke/ducklake-r)
 <!-- badges: end -->
 
 ducklake is an R package that brings versioned data lake infrastructure

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,22 @@
+# cran-comments
+
+## R CMD check results
+
+0 errors | 0 warnings | 0 notes
+
+* This is a new release.
+
+## Test environments
+
+* local macOS (aarch64), R release
+* win-builder (devel and release)
+* mac-builder (release)
+
+## Notes for reviewers
+
+* ducklake wraps the 'ducklake' DuckDB extension, which is not bundled with
+  the duckdb R package and needs network access to install on first use.
+  Everything that depends on the extension is guarded: tests skip via
+  `skip_on_cran()` (through a shared helper), vignette chunks evaluate only
+  when the extension can be loaded, and all examples are wrapped in
+  `\dontrun{}`.

--- a/tests/testthat/helper-setup.R
+++ b/tests/testthat/helper-setup.R
@@ -6,12 +6,31 @@ get_ducklake_env <- function() {
   asNamespace("ducklake")[[".ducklake_env"]]
 }
 
+#' Skip tests that need the ducklake DuckDB extension
+#'
+#' The extension is not bundled with the duckdb R package: installing it
+#' needs network access on first use, so these tests cannot run on CRAN.
+skip_if_no_ducklake <- function() {
+  testthat::skip_on_cran()
+  ok <- tryCatch(
+    {
+      DBI::dbExecute(ducklake::get_ducklake_connection(), "LOAD ducklake;")
+      TRUE
+    },
+    error = function(e) FALSE
+  )
+  testthat::skip_if_not(ok, "ducklake extension not available")
+  invisible(TRUE)
+}
+
 #' Create a temporary ducklake for testing
 #'
 #' Creates a test ducklake in a temporary directory with proper DuckLake catalog
 #' 
 #' @return List with ducklake_name, temp_dir, lake_path, and conn
 create_temp_ducklake <- function() {
+  skip_if_no_ducklake()
+
   temp_dir <- tempfile()
   dir.create(temp_dir, showWarnings = FALSE, recursive = TRUE)
   

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,10 +1,14 @@
 # Setup file - runs once before all tests
-# Install ducklake extension globally for all tests
-suppressMessages({
-  tryCatch({
-    ducklake::install_ducklake()
-  }, error = function(e) {
-    # Extension might already be installed, that's ok
-    NULL
+# Install the ducklake extension for the local/CI test runs that use it.
+# Skipped on CRAN: installing an extension needs network access, and every
+# test that would use it skips itself via skip_if_no_ducklake().
+if (identical(Sys.getenv("NOT_CRAN"), "true")) {
+  suppressMessages({
+    tryCatch({
+      ducklake::install_ducklake()
+    }, error = function(e) {
+      # Extension might already be installed, that's ok
+      NULL
+    })
   })
-})
+}

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -68,6 +68,7 @@ test_that("set_ducklake_connection rejects invalid input", {
 })
 
 test_that("shutdown releases DuckLake catalog file locks", {
+  skip_if_no_ducklake()
   skip_if_not_installed("duckdb")
   skip_if_not_installed("fs")
 

--- a/tests/testthat/test-data-inlining.R
+++ b/tests/testthat/test-data-inlining.R
@@ -139,6 +139,7 @@ test_that("set_inlining_row_limit rejects negative values", {
 })
 
 test_that("set_inlining_row_limit(0) disables inlining", {
+  skip_if_no_ducklake()
   skip_if_not_installed("duckdb")
   skip_if_not_installed("dplyr")
 

--- a/tests/testthat/test-hardening.R
+++ b/tests/testthat/test-hardening.R
@@ -62,6 +62,7 @@ test_that("build_attach_sql adds ENCRYPTED TRUE when requested", {
 })
 
 test_that("encrypted lakes round-trip data", {
+  skip_if_no_ducklake()
   skip_if_not_installed("duckdb")
 
   temp_dir <- tempfile()
@@ -179,6 +180,7 @@ test_that("update_table handles values containing the word WHERE", {
 })
 
 test_that("get_ducklake_backend tracks multiple lakes independently", {
+  skip_if_no_ducklake()
   skip_if_not_installed("duckdb")
 
   dir_a <- tempfile(); dir.create(dir_a, recursive = TRUE)

--- a/tests/testthat/test-maintenance.R
+++ b/tests/testthat/test-maintenance.R
@@ -109,6 +109,7 @@ test_that("rewrite_data_files rewrites heavily deleted files", {
 })
 
 test_that("delete_orphaned_files removes only untracked files", {
+  skip_if_no_ducklake()
   skip_if_not_installed("duckdb")
   skip_if_not_installed("dplyr")
 
@@ -146,6 +147,7 @@ test_that("delete_orphaned_files removes only untracked files", {
 })
 
 test_that("doubled slashes in lake_path don't make live files look orphaned", {
+  skip_if_no_ducklake()
   skip_if_not_installed("duckdb")
   skip_if_not_installed("dplyr")
 

--- a/tests/testthat/test-multi-backend.R
+++ b/tests/testthat/test-multi-backend.R
@@ -164,6 +164,7 @@ test_that("build_attach_sql includes OVERRIDE_DATA_PATH when requested", {
 # --- SQLite backend end-to-end ---
 
 test_that("SQLite backend: create table, query, and time travel", {
+  skip_if_no_ducklake()
   skip_if_not_installed("duckdb")
   skip_if_not_installed("dplyr")
 

--- a/tests/testthat/test-vignette-workflows.R
+++ b/tests/testthat/test-vignette-workflows.R
@@ -15,6 +15,7 @@
 
 # NOTE: This test runs first to ensure a clean connection state for file-based backup
 test_that("storage-and-backups.Rmd workflow: backup and restore", {
+  skip_if_no_ducklake()
   skip_if_not_installed("duckdb")
   skip_if_not_installed("dplyr")
   skip_if_not_installed("fs")
@@ -99,6 +100,7 @@ test_that("storage-and-backups.Rmd workflow: backup and restore", {
 })
 
 test_that("backup catalog file is non-empty (singleton connection)", {
+  skip_if_no_ducklake()
   skip_if_not_installed("duckdb")
   skip_if_not_installed("dplyr")
   skip_if_not_installed("fs")

--- a/vignettes/clinical-trial-datalake.Rmd
+++ b/vignettes/clinical-trial-datalake.Rmd
@@ -8,17 +8,27 @@ vignette: >
 ---
 
 ```{r, include = FALSE}
-# Skip this vignette if optional packages are not available
-# or if the duckdb R package is too old to support the ducklake v1.0 extension
+# Skip this vignette if optional packages are not available, or where the
+# ducklake DuckDB extension is unusable: it needs duckdb >= 1.5.1 and, when
+# not already cached, network access to install (not available on CRAN).
 has_deps <- requireNamespace("pharmaversesdtm", quietly = TRUE) &&
   requireNamespace("admiral", quietly = TRUE)
-duckdb_version_ok <- tryCatch({
-  packageVersion("duckdb") >= "1.5.1"
+ducklake_available <- tryCatch({
+  packageVersion("duckdb") >= "1.5.1" && {
+    con <- DBI::dbConnect(duckdb::duckdb())
+    ok <- tryCatch({
+      DBI::dbExecute(con, "INSTALL ducklake;")
+      DBI::dbExecute(con, "LOAD ducklake;")
+      TRUE
+    }, error = function(e) FALSE)
+    DBI::dbDisconnect(con, shutdown = TRUE)
+    ok
+  }
 }, error = function(e) FALSE)
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  eval = has_deps && duckdb_version_ok
+  eval = has_deps && ducklake_available
 )
 # Use a unique temp directory for this vignette to avoid conflicts during R CMD check
 vignette_temp_dir <- file.path(tempdir(), "clinical_trial_vignette")

--- a/vignettes/data-inlining.Rmd
+++ b/vignettes/data-inlining.Rmd
@@ -8,14 +8,25 @@ vignette: >
 ---
 
 ```{r, include = FALSE}
-# Skip if the duckdb R package is too old to support the ducklake v1.0 extension
-duckdb_version_ok <- tryCatch({
-  packageVersion("duckdb") >= "1.5.1"
+# Evaluate chunks only where the ducklake DuckDB extension is usable: needs
+# duckdb >= 1.5.1 and, when not already cached, network access to install the
+# extension (not available on CRAN).
+ducklake_available <- tryCatch({
+  packageVersion("duckdb") >= "1.5.1" && {
+    con <- DBI::dbConnect(duckdb::duckdb())
+    ok <- tryCatch({
+      DBI::dbExecute(con, "INSTALL ducklake;")
+      DBI::dbExecute(con, "LOAD ducklake;")
+      TRUE
+    }, error = function(e) FALSE)
+    DBI::dbDisconnect(con, shutdown = TRUE)
+    ok
+  }
 }, error = function(e) FALSE)
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  eval = duckdb_version_ok
+  eval = ducklake_available
 )
 # Use a unique temp directory for this vignette to avoid conflicts during R CMD check
 vignette_temp_dir <- file.path(tempdir(), "data_inlining_vignette")

--- a/vignettes/ducklake.Rmd
+++ b/vignettes/ducklake.Rmd
@@ -8,9 +8,25 @@ vignette: >
 ---
 
 ```{r, include = FALSE}
+# Evaluate chunks only where the ducklake DuckDB extension is usable: needs
+# duckdb >= 1.5.1 and, when not already cached, network access to install the
+# extension (not available on CRAN).
+ducklake_available <- tryCatch({
+  packageVersion("duckdb") >= "1.5.1" && {
+    con <- DBI::dbConnect(duckdb::duckdb())
+    ok <- tryCatch({
+      DBI::dbExecute(con, "INSTALL ducklake;")
+      DBI::dbExecute(con, "LOAD ducklake;")
+      TRUE
+    }, error = function(e) FALSE)
+    DBI::dbDisconnect(con, shutdown = TRUE)
+    ok
+  }
+}, error = function(e) FALSE)
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  eval = ducklake_available
 )
 # Use a unique temp directory for this vignette to avoid conflicts during R CMD check
 vignette_temp_dir <- file.path(tempdir(), "ducklake_vignette")

--- a/vignettes/modifying-tables.Rmd
+++ b/vignettes/modifying-tables.Rmd
@@ -8,14 +8,25 @@ vignette: >
 ---
 
 ```{r, include = FALSE}
-# Skip if the duckdb R package is too old to support the ducklake v1.0 extension
-duckdb_version_ok <- tryCatch({
-  packageVersion("duckdb") >= "1.5.1"
+# Evaluate chunks only where the ducklake DuckDB extension is usable: needs
+# duckdb >= 1.5.1 and, when not already cached, network access to install the
+# extension (not available on CRAN).
+ducklake_available <- tryCatch({
+  packageVersion("duckdb") >= "1.5.1" && {
+    con <- DBI::dbConnect(duckdb::duckdb())
+    ok <- tryCatch({
+      DBI::dbExecute(con, "INSTALL ducklake;")
+      DBI::dbExecute(con, "LOAD ducklake;")
+      TRUE
+    }, error = function(e) FALSE)
+    DBI::dbDisconnect(con, shutdown = TRUE)
+    ok
+  }
 }, error = function(e) FALSE)
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  eval = duckdb_version_ok
+  eval = ducklake_available
 )
 # Use a unique temp directory for this vignette to avoid conflicts during R CMD check
 vignette_temp_dir <- file.path(tempdir(), "modifying_tables_vignette")

--- a/vignettes/storage-and-backups.Rmd
+++ b/vignettes/storage-and-backups.Rmd
@@ -8,14 +8,25 @@ vignette: >
 ---
 
 ```{r, include = FALSE}
-# Skip if the duckdb R package is too old to support the ducklake v1.0 extension
-duckdb_version_ok <- tryCatch({
-  packageVersion("duckdb") >= "1.5.1"
+# Evaluate chunks only where the ducklake DuckDB extension is usable: needs
+# duckdb >= 1.5.1 and, when not already cached, network access to install the
+# extension (not available on CRAN).
+ducklake_available <- tryCatch({
+  packageVersion("duckdb") >= "1.5.1" && {
+    con <- DBI::dbConnect(duckdb::duckdb())
+    ok <- tryCatch({
+      DBI::dbExecute(con, "INSTALL ducklake;")
+      DBI::dbExecute(con, "LOAD ducklake;")
+      TRUE
+    }, error = function(e) FALSE)
+    DBI::dbDisconnect(con, shutdown = TRUE)
+    ok
+  }
 }, error = function(e) FALSE)
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  eval = duckdb_version_ok
+  eval = ducklake_available
 )
 # Use a unique temp directory for this vignette to avoid conflicts during R CMD check
 vignette_temp_dir <- file.path(tempdir(), "storage_backups_vignette")

--- a/vignettes/time-travel.Rmd
+++ b/vignettes/time-travel.Rmd
@@ -8,14 +8,25 @@ vignette: >
 ---
 
 ```{r, include = FALSE}
-# Skip if the duckdb R package is too old to support the ducklake v1.0 extension
-duckdb_version_ok <- tryCatch({
-  packageVersion("duckdb") >= "1.5.1"
+# Evaluate chunks only where the ducklake DuckDB extension is usable: needs
+# duckdb >= 1.5.1 and, when not already cached, network access to install the
+# extension (not available on CRAN).
+ducklake_available <- tryCatch({
+  packageVersion("duckdb") >= "1.5.1" && {
+    con <- DBI::dbConnect(duckdb::duckdb())
+    ok <- tryCatch({
+      DBI::dbExecute(con, "INSTALL ducklake;")
+      DBI::dbExecute(con, "LOAD ducklake;")
+      TRUE
+    }, error = function(e) FALSE)
+    DBI::dbDisconnect(con, shutdown = TRUE)
+    ok
+  }
 }, error = function(e) FALSE)
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  eval = duckdb_version_ok
+  eval = ducklake_available
 )
 # Use a unique temp directory for this vignette to avoid conflicts during R CMD check
 vignette_temp_dir <- file.path(tempdir(), "time_travel_vignette")

--- a/vignettes/transactions.Rmd
+++ b/vignettes/transactions.Rmd
@@ -8,14 +8,25 @@ vignette: >
 ---
 
 ```{r, include = FALSE}
-# Skip if the duckdb R package is too old to support the ducklake v1.0 extension
-duckdb_version_ok <- tryCatch({
-  packageVersion("duckdb") >= "1.5.1"
+# Evaluate chunks only where the ducklake DuckDB extension is usable: needs
+# duckdb >= 1.5.1 and, when not already cached, network access to install the
+# extension (not available on CRAN).
+ducklake_available <- tryCatch({
+  packageVersion("duckdb") >= "1.5.1" && {
+    con <- DBI::dbConnect(duckdb::duckdb())
+    ok <- tryCatch({
+      DBI::dbExecute(con, "INSTALL ducklake;")
+      DBI::dbExecute(con, "LOAD ducklake;")
+      TRUE
+    }, error = function(e) FALSE)
+    DBI::dbDisconnect(con, shutdown = TRUE)
+    ok
+  }
 }, error = function(e) FALSE)
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  eval = duckdb_version_ok
+  eval = ducklake_available
 )
 # Use a unique temp directory for this vignette to avoid conflicts during R CMD check
 vignette_temp_dir <- file.path(tempdir(), "transactions_vignette")

--- a/vignettes/visualizing-your-lake.Rmd
+++ b/vignettes/visualizing-your-lake.Rmd
@@ -8,16 +8,27 @@ vignette: >
 ---
 
 ```{r, include = FALSE}
-# Skip if the duckdb R package is too old to support the ducklake v1.0 extension
-duckdb_version_ok <- tryCatch({
-  packageVersion("duckdb") >= "1.5.1"
+# Evaluate chunks only where the ducklake DuckDB extension is usable: needs
+# duckdb >= 1.5.1 and, when not already cached, network access to install the
+# extension (not available on CRAN).
+ducklake_available <- tryCatch({
+  packageVersion("duckdb") >= "1.5.1" && {
+    con <- DBI::dbConnect(duckdb::duckdb())
+    ok <- tryCatch({
+      DBI::dbExecute(con, "INSTALL ducklake;")
+      DBI::dbExecute(con, "LOAD ducklake;")
+      TRUE
+    }, error = function(e) FALSE)
+    DBI::dbDisconnect(con, shutdown = TRUE)
+    ok
+  }
 }, error = function(e) FALSE)
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   fig.width = 7,
   fig.height = 4,
-  eval = duckdb_version_ok && requireNamespace("ggplot2", quietly = TRUE)
+  eval = ducklake_available && requireNamespace("ggplot2", quietly = TRUE)
 )
 # Use a unique temp directory for this vignette to avoid conflicts during R CMD check
 vignette_temp_dir <- file.path(tempdir(), "visualizing_your_lake_vignette")


### PR DESCRIPTION
Makes the package submittable to CRAN, where the ducklake DuckDB extension can't be installed (no network on the builders). **Stacked on #32; merges last.** GitHub will retarget this to main as the stack merges.

- New `skip_if_no_ducklake()` test helper (skip_on_cran + extension check), wired into `create_temp_ducklake()` so every live-lake test inherits it, plus explicit calls in the tests that attach directly. Verified with `env -u NOT_CRAN R CMD check --as-cran`: 0 errors/warnings, 100+ mock-based tests still run on CRAN while extension-dependent ones skip. (Note: `devtools::test()` and `testthat::test_local()` force `NOT_CRAN=true`, so only a raw `R CMD check` can demonstrate the skips.)
- Every vignette's eval gate now checks that the extension can actually load, not just the duckdb version, so CRAN's vignette rebuild succeeds without network while local and pkgdown builds keep full output.
- DESCRIPTION: `R (>= 4.1)` declared (test files parse the base pipe even when skipped), software names quoted, DuckLake linked.
- `cran-comments.md` added (build-ignored); codecov badge links point at app.codecov.io per the URL check.